### PR TITLE
Add basic recoverability.

### DIFF
--- a/doctrine.js
+++ b/doctrine.js
@@ -888,7 +888,7 @@
                     expr = {
                         type: Syntax.ParameterType,
                         name: expr.name,
-                        expression: parseTypeExpression(),
+                        expression: parseTypeExpression()
                     };
                 }
                 if (token === Token.EQUAL) {
@@ -1197,7 +1197,8 @@
     (function (exports) {
         var index,
             length,
-            source;
+            source,
+            recoverable;
 
         function advance() {
             var ch = source[index];
@@ -1374,7 +1375,7 @@
             title = scanTitle();
 
             // empty title
-            if (!title) {
+            if (!title && !recoverable) {
                 return;
             }
 
@@ -1389,7 +1390,7 @@
             // type required titles
             if (isTypeParameterRequired(title)) {
                 tag.type = parseType(title, last);
-                if (!tag.type) {
+                if (!tag.type && !recoverable) {
                     return;
                 }
             }
@@ -1397,7 +1398,7 @@
             // param, property requires name
             if (title === 'param' || title === 'property') {
                 tag.name = parseName(last);
-                if (!tag.name) {
+                if (!tag.name && !recoverable) {
                     return;
                 }
             }
@@ -1450,6 +1451,7 @@
 
             length = source.length;
             index = 0;
+            recoverable = options.recoverable;
 
             description = trim(scanDescription());
             

--- a/test/parse.js
+++ b/test/parse.js
@@ -380,7 +380,192 @@ describe('invalid tags', function() {
                 " */"
             ].join('\n'), { tags: ['a', 1], unwrap:true }).should.throw();
      });
+});
 
+describe('recovery tests', function() {
+	it ('not recoverable', function () {
+		var res = doctrine.parse(
+            [
+                "@param f"
+            ].join('\n'), { recoverable: false });
+            
+         // parser will mistakenly think that the type is 'f' and there is no name
+         res.tags.should.have.length(0);
+	});
+	
+	it ('params 1', function () {
+		var res = doctrine.parse(
+            [
+                "@param f"
+            ].join('\n'), { recoverable: true });
+            
+         // parser will mistakenly think that the type is 'f' and there is no name
+         res.tags.should.have.length(1);
+         res.tags[0].should.have.property('title', 'param');
+         res.tags[0].should.have.property('type');
+         res.tags[0].type.should.have.property('name', 'f');
+         res.tags[0].type.should.have.property('type', 'NameExpression');
+         res.tags[0].should.not.have.property('name');
+	});
+	it ('params 2', function () {
+		var res = doctrine.parse(
+            [
+                "@param f",
+                "@param {string} f2"
+            ].join('\n'), { recoverable: true });
+            
+         // ensure second parameter is OK
+         res.tags.should.have.length(2);
+         res.tags[0].should.have.property('title', 'param');
+         res.tags[0].should.have.property('type');
+         res.tags[0].type.should.have.property('name', 'f');
+         res.tags[0].type.should.have.property('type', 'NameExpression');
+         res.tags[0].should.not.have.property('name');
+         
+         res.tags[1].should.have.property('title', 'param');
+         res.tags[1].should.have.property('type');
+         res.tags[1].type.should.have.property('name', 'string');
+         res.tags[1].type.should.have.property('type', 'NameExpression');
+         res.tags[1].should.have.property('name', 'f2');
+	});
+	
+	it ('params 2', function () {
+		var res = doctrine.parse(
+            [
+                "@param string f",
+                "@param {string} f2"
+            ].join('\n'), { recoverable: true });
+            
+         // ensure first parameter is OK even with invalid type name
+         res.tags.should.have.length(2);
+         res.tags[0].should.have.property('title', 'param');
+         res.tags[0].should.have.property('type');
+         res.tags[0].type.should.have.property('name', 'string');
+         res.tags[0].type.should.have.property('type', 'NameExpression');
+         res.tags[0].should.have.property('name', 'f');
+         
+         res.tags[1].should.have.property('title', 'param');
+         res.tags[1].should.have.property('type');
+         res.tags[1].type.should.have.property('name', 'string');
+         res.tags[1].type.should.have.property('type', 'NameExpression');
+         res.tags[1].should.have.property('name', 'f2');
+	});
+	
+	it ('return 1', function() {
+		var res = doctrine.parse(
+            [
+                "@returns"
+            ].join('\n'), { recoverable: true });
+            
+         // return tag should exist
+         res.tags.should.have.length(1);
+         res.tags[0].should.have.property('title', 'returns');
+         res.tags[0].should.not.have.property('type');
+	});
+	it ('return 2', function() {
+		var res = doctrine.parse(
+            [
+                "@returns",
+				"@param {string} f2"
+            ].join('\n'), { recoverable: true });
+            
+         // return tag should exist as well as next tag
+         res.tags.should.have.length(2);
+         res.tags[0].should.have.property('title', 'returns');
+         res.tags[0].should.not.have.property('type');
+         
+         res.tags[1].should.have.property('title', 'param');
+         res.tags[1].should.have.property('type');
+         res.tags[1].type.should.have.property('name', 'string');
+         res.tags[1].type.should.have.property('type', 'NameExpression');
+         res.tags[1].should.have.property('name', 'f2');
+	});
+	
+	it ('extra @ 1', function() {
+		var res = doctrine.parse(
+            [
+                "@",
+                "@returns",
+				"@param {string} f2"
+            ].join('\n'), { recoverable: true });
+            
+         // empty tag name shouldn't affect subsequent tags
+         res.tags.should.have.length(3);
+         res.tags[0].should.have.property('title', '');
+         res.tags[0].should.not.have.property('type');
+
+         res.tags[1].should.have.property('title', 'returns');
+         res.tags[1].should.not.have.property('type');
+         
+         res.tags[2].should.have.property('title', 'param');
+         res.tags[2].should.have.property('type');
+         res.tags[2].type.should.have.property('name', 'string');
+         res.tags[2].type.should.have.property('type', 'NameExpression');
+         res.tags[2].should.have.property('name', 'f2');
+	});
+	
+	it ('extra @ 2', function() {
+		var res = doctrine.parse(
+            [
+                "@ invalid name",
+				"@param {string} f2"
+            ].join('\n'), { recoverable: true });
+            
+         // empty tag name shouldn't affect subsequent tags
+         res.tags.should.have.length(2);
+         res.tags[0].should.have.property('title', '');
+         res.tags[0].should.not.have.property('type');
+         res.tags[0].should.not.have.property('name');
+         res.tags[0].should.have.property('description', 'invalid name');
+         
+         res.tags[1].should.have.property('title', 'param');
+         res.tags[1].should.have.property('type');
+         res.tags[1].type.should.have.property('name', 'string');
+         res.tags[1].type.should.have.property('type', 'NameExpression');
+         res.tags[1].should.have.property('name', 'f2');
+	});
+
+	it ('invalid tag 1', function() {
+		var res = doctrine.parse(
+            [
+                "@111 invalid name",
+				"@param {string} f2"
+            ].join('\n'), { recoverable: true });
+            
+         // invalid tag name shouldn't affect subsequent tags
+         res.tags.should.have.length(2);
+         res.tags[0].should.have.property('title', '111');
+         res.tags[0].should.not.have.property('type');
+         res.tags[0].should.not.have.property('name');
+         res.tags[0].should.have.property('description', 'invalid name');
+         
+         res.tags[1].should.have.property('title', 'param');
+         res.tags[1].should.have.property('type');
+         res.tags[1].type.should.have.property('name', 'string');
+         res.tags[1].type.should.have.property('type', 'NameExpression');
+         res.tags[1].should.have.property('name', 'f2');
+	});
+
+	it ('invalid tag 1', function() {
+		var res = doctrine.parse(
+            [
+                "@111",
+				"@param {string} f2"
+            ].join('\n'), { recoverable: true });
+            
+         // invalid tag name shouldn't affect subsequent tags
+         res.tags.should.have.length(2);
+         res.tags[0].should.have.property('title', '111');
+         res.tags[0].should.not.have.property('type');
+         res.tags[0].should.not.have.property('name');
+         res.tags[0].should.have.property('description', null);
+         
+         res.tags[1].should.have.property('title', 'param');
+         res.tags[1].should.have.property('type');
+         res.tags[1].type.should.have.property('name', 'string');
+         res.tags[1].type.should.have.property('type', 'NameExpression');
+         res.tags[1].should.have.property('name', 'f2');
+	});
 
 });
 


### PR DESCRIPTION
Second try at a pull request.  This one added a few more tests and is based off of a different branch.

This pull request contains basic support for recoverability.  Now, simple problems like forgetting to include a tag name or a tag type will not break parsing of subsequent tags.  eg-

```
@param arg0
@param {string} arg1
```

parsing that will return a list of two tags.  The first will have no name, and a type of 'arg0'  The second will be a proper param tag.

To ensure backwards compatibility, I added a new option.  

> recoverable (boolean) default false.  Set to true if you want to enable recovery.

In my opinion, this should be defaulted to true, but I wouldn't want to break any existing programs that assume no recoverability by default.

Some tests are included, but I may want to add more. 
