### PR TITLE
fixed handling of '*' followed immediately by a blank line

### DIFF
--- a/doctrine.js
+++ b/doctrine.js
@@ -171,7 +171,7 @@
                 if (!isWhiteSpace(ch)) {
                     result += ch;
                 }
-                mode = AFTER_STAR;
+                mode = isLineTerminator(ch) ? BEFORE_STAR : AFTER_STAR;
                 break;
 
             case AFTER_STAR:

--- a/test/parse.js
+++ b/test/parse.js
@@ -150,6 +150,28 @@ describe('parse', function () {
         });
         res.tags[0].should.have.property('description', 'description');
     });
+
+    it('description and param separated by blank line', function () {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * Description",
+                " * blah blah blah",
+                " *",
+                " * @param string name description",
+                "*/"
+            ].join('\n'), { unwrap: true });
+        res.description.should.eql('Description\nblah blah blah');
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'param');
+        res.tags[0].should.have.property('name', 'name');
+        res.tags[0].should.have.property('type');
+        res.tags[0].type.should.eql({
+            type: 'NameExpression',
+            name: 'string'
+        });
+        res.tags[0].should.have.property('description', 'description');
+    });
 });
 
 describe('parseType', function () {

--- a/test/unwrap.js
+++ b/test/unwrap.js
@@ -49,5 +49,9 @@ describe('unwrapComment', function () {
   it('2 lines with space', function () {
     doctrine.unwrapComment('/**x\n *    y\n*/').should.equal('x\n   y\n');
   });
+
+  it('3 lines with blank line', function () {
+    doctrine.unwrapComment('/**x\n *\n \* y\n*/').should.equal('x\n\ny\n');
+  });
 });
 /* vim: set sw=4 ts=4 et tw=80 : */


### PR DESCRIPTION
I was confused at first when I tried out doctrine because it failed to parse something like this:

``` javascript
/**
 * Description
 *
 * @param {type} name blah blah blah
 */
```

After some trial and error I discovered it was because of that middle `*` character, followed immediately by a newline character. I fixed the issue by adding a space after the `*`.

This change fixes `unwrapComment` so that `*` characters do NOT have to be followed by a space in order to be ignored.
