### PR TITLE
Handle default param values

### DIFF
--- a/test/parse.js
+++ b/test/parse.js
@@ -575,7 +575,6 @@ describe('optional params', function() {
         });
     });
     it('success 1', function() {
-
         doctrine.parse(
         ["/**", " * @param {String} [val]", " */"].join('\n'), {
             unwrap: true, sloppy: true
@@ -612,6 +611,28 @@ describe('optional params', function() {
                     }
                 },
                 "name": "val"
+            }]
+        });
+    });
+
+    it('success 3', function() {
+        doctrine.parse(
+            ["/**", " * @param {String=} [val=abc] some description", " */"].join('\n'),
+            { unwrap: true, sloppy: true}
+        ).should.eql({
+            "description": "",
+            "tags": [{
+                "title": "param",
+                "description": "some description",
+                "type": {
+                    "type": "OptionalType",
+                    "expression": {
+                        "type": "NameExpression",
+                        "name": "String"
+                    }
+                },
+                "name": "val",
+                "default": "abc"
             }]
         });
     });


### PR DESCRIPTION
JSDoc params can provide a default value by wrapping the param name in square brackets (to make it optional) then putting the default value after the equals symbol:

```
@param {String} [paramName=default param value]
```

This PR provides support for this, until doctrine is updated to allow configurable JSDoc tags.  I have added a new test case for the default value and all the other tests pass.

It would be great if you could merge this in as it is blocking me from using doctrine in a project.
