### PR TITLE
add support for @param tags w/o a type

### DIFF
--- a/doctrine.js
+++ b/doctrine.js
@@ -1614,7 +1614,7 @@
 
             // type required titles
             if (isTypeParameterRequired(title)) {
-                tag.type = parseType(title, last);
+                type = tag.type = parseType(title, last);
                 if (!tag.type) {
                     addError("Missing or invalid tag type");
                     if (!recoverable) {
@@ -1627,12 +1627,11 @@
             if (title === 'param' || title === 'property') {
                 tag.name = parseName(last, sloppy && title === 'param');
                 if (!tag.name) {
-                    // param actually does not require type:
-                    // http://usejsdoc.org/tags-param.html
-                    // it's possible the name has already been parsed but
-                    // interpreted as a type
-                    if (title === 'param' && tag.type.name) {
-                        tag.name = tag.type.name;
+                    // it's possible the name has already been parsed but interpreted as a type
+                    // it's also possible this is a sloppy declaration, in which case it will be
+                    // fixed at the end
+                    if (title === 'param' && type.name) {
+                        tag.name = type.name;
                         tag.type = null;
                     } else {
                         addError("Missing or invalid tag name");
@@ -1664,6 +1663,20 @@
             if (description) {
                 tag.description = description;
             }
+
+            // un-fix potentially sloppy declaration
+            if (title === 'param' && !tag.type && description.charAt(0) === '[') {
+                tag.type = type;
+                tag.name = undefined;
+
+                if (!sloppy) {
+                    addError("Missing or invalid tag name");
+                    if (!recoverable) {
+                        return;
+                    }
+                }
+            }
+
             index = last;
             return tag;
         }

--- a/test/parse.js
+++ b/test/parse.js
@@ -662,13 +662,11 @@ describe('recovery tests', function() {
                 "@param {string} f2"
             ].join('\n'), { recoverable: true });
 
-         // ensure second parameter is OK
+         // ensure both parameters are OK
          res.tags.should.have.length(2);
          res.tags[0].should.have.property('title', 'param');
-         res.tags[0].should.have.property('type');
-         res.tags[0].type.should.have.property('name', 'f');
-         res.tags[0].type.should.have.property('type', 'NameExpression');
-         res.tags[0].should.not.have.property('name');
+         res.tags[0].should.have.property('type', null);
+         res.tags[0].should.have.property('name', 'f');
 
          res.tags[1].should.have.property('title', 'param');
          res.tags[1].should.have.property('type');


### PR DESCRIPTION
According to [the JsDoc docs](http://usejsdoc.org/tags-param.html), the `@param` tag does not require a type. So this should be legal:

``` javascript
/**
 * @param somebody
 */
function sayHello(somebody) {
    alert('Hello ' + somebody);
}
```

This patch updates doctrine to parse the `@param` tag just fine in this case, w/ a `type` of `null`.
