### PR TITLE
add support for "array-style" type declarations

### DIFF
--- a/doctrine.js
+++ b/doctrine.js
@@ -1029,6 +1029,7 @@
         //   | BasicTypeExpression '?'
         //   | BasicTypeExpression '!'
         //   | '?'
+        //   | BasicTypeExpression '[]'
         function parseTypeExpression() {
             var expr;
 
@@ -1072,6 +1073,19 @@
                     type: Syntax.NullableType,
                     expression: expr,
                     prefix: false
+                };
+            }
+
+            if (token === Token.LBRACK) {
+                consume(Token.LBRACK);
+                consume(Token.RBRACK, 'expected an array-style type declaration (' + value + '[])');
+                return {
+                    type: Syntax.TypeApplication,
+                    expression: {
+                        type: Syntax.NameExpression,
+                        name: 'Array'
+                    },
+                    applications: [expr]
                 };
             }
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -275,6 +275,21 @@ describe('parseType', function () {
         });
     });
 
+    it('array-style type application', function () {
+        var type = doctrine.parseType("String[]");
+        type.should.eql({
+            type: 'TypeApplication',
+            expression: {
+                type: 'NameExpression',
+                name: 'Array'
+            },
+            applications: [{
+                type: 'NameExpression',
+                name: 'String'
+            }]
+        });
+    });
+
     it('function type simple', function () {
         var type = doctrine.parseType("function()");
         type.should.eql({
@@ -283,6 +298,7 @@ describe('parseType', function () {
 		 "result": null
 		});
     });
+
     it('function type with name', function () {
         var type = doctrine.parseType("function(a)");
         type.should.eql({


### PR DESCRIPTION
According to [the JsDoc docs](http://usejsdoc.org/tags-type.html) these two syntaxes should be interchangeable:

```
{Array.<MyClass>}
{MyClass[]}
```

This change updates doctrine to support the latter same as the former.
