### PR TITLE
Adding in nested properties for @param. fixes #37

### DIFF
--- a/doctrine.js
+++ b/doctrine.js
@@ -128,11 +128,15 @@
     }
 
     function isParamTitle(title) {
-        return title === 'param' || title === 'arguments' || title === 'arg';
+        return title === 'param' || title === 'argument' || title === 'arg';
     }
 
     function isProperty(title) {
         return title === 'property' || title === 'prop';
+    }
+
+    function isAllowedNested(title) {
+        return isProperty(title) || isParamTitle(title);
     }
 
     function isTypeParameterRequired(title) {
@@ -1707,7 +1711,7 @@
 
             // param, property requires name
             if (isParamTitle(this._title) || isProperty(this._title)) {
-                this._tag.name = parseName(this._last, sloppy && isParamTitle(this._title), isProperty(this._title));
+                this._tag.name = parseName(this._last, sloppy && isParamTitle(this._title), isAllowedNested(this._title));
                 if (!this._tag.name) {
                     // it's possible the name has already been parsed but interpreted as a type
                     // it's also possible this is a sloppy declaration, in which case it will be

--- a/test/parse.js
+++ b/test/parse.js
@@ -81,6 +81,57 @@ describe('parse', function () {
         });
     });
 
+    it('param with properties', function () {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * @param {String} user.name",
+                "*/"
+            ].join('\n'), { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'param');
+        res.tags[0].should.have.property('name', 'user.name');
+        res.tags[0].should.have.property('type');
+        res.tags[0].type.should.eql({
+            type: 'NameExpression',
+            name: 'String'
+        });
+    });
+
+    it('arg with properties', function () {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * @arg {String} user.name",
+                "*/"
+            ].join('\n'), { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'arg');
+        res.tags[0].should.have.property('name', 'user.name');
+        res.tags[0].should.have.property('type');
+        res.tags[0].type.should.eql({
+            type: 'NameExpression',
+            name: 'String'
+        });
+    });
+
+    it('argument with properties', function () {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * @argument {String} user.name",
+                "*/"
+            ].join('\n'), { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'argument');
+        res.tags[0].should.have.property('name', 'user.name');
+        res.tags[0].should.have.property('type');
+        res.tags[0].type.should.eql({
+            type: 'NameExpression',
+            name: 'String'
+        });
+    });
+
     it('param typeless', function () {
         var res = doctrine.parse(
         [
@@ -107,6 +158,20 @@ describe('parse', function () {
             title: 'param',
             type: null,
             name: 'userName',
+            description: 'Something descriptive'
+        });
+
+        var res = doctrine.parse(
+        [
+            "/**",
+            " * @param user.name Something descriptive",
+            "*/"
+        ].join('\n'), { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.eql({
+            title: 'param',
+            type: null,
+            name: 'user.name',
             description: 'Something descriptive'
         });
     });


### PR DESCRIPTION
I added in tests for @arg, @argument and @param all using nested properties as mentioned in: https://code.google.com/p/jsdoc-toolkit/wiki/TagParam#Parameters_With_Properties

This work uncovered that @argument wasn't working either, fixed within this issue.
