### PR TITLE
Fail to parse "@type {[?]}"

### DIFF
--- a/doctrine.js
+++ b/doctrine.js
@@ -1120,7 +1120,8 @@
             if (token === Token.QUESTION) {
                 consume(Token.QUESTION);
                 if (token === Token.COMMA || token === Token.EQUAL || token === Token.RBRACE ||
-                        token === Token.RPAREN || token === Token.PIPE || token === Token.EOF) {
+                        token === Token.RPAREN || token === Token.PIPE || token === Token.EOF ||
+                        token === Token.RBRACK) {
                     return {
                         type: Syntax.NullableLiteral
                     };

--- a/test/parse.js
+++ b/test/parse.js
@@ -1071,6 +1071,26 @@ describe('parseType', function () {
         });
     });
 
+    it('array type of all literal', function () {
+        var type = doctrine.parseType("[*]");
+        type.should.eql({
+            type: 'ArrayType',
+            elements: [{
+                type: 'AllLiteral'
+            }]
+        });
+    });
+
+    it('array type of nullable literal', function () {
+        var type = doctrine.parseType("[?]");
+        type.should.eql({
+            type: 'ArrayType',
+            elements: [{
+                type: 'NullableLiteral'
+            }]
+        });
+    });
+
     it('comma last record type', function () {
         var type = doctrine.parseType("{,}");
         type.should.eql({


### PR DESCRIPTION
Fail to parse an array type of nullable literal `@type {[?]}`.
(all literal `@type {[*]}` can be parsed.)
