### PR TITLE
Allow namepaths in @name

### DIFF
--- a/doctrine.js
+++ b/doctrine.js
@@ -1614,8 +1614,8 @@
             name += scanIdentifier(last);
 
             if (allowNestedParams) {
-                while (source[index] === '.') {
-                    name += '.';
+                while (source[index] === '.' || source[index] === '#' || source[index] === '~') {
+                    name += source[index];
                     index += 1;
                     name += scanIdentifier(last);
                 }

--- a/test/parse.js
+++ b/test/parse.js
@@ -342,6 +342,20 @@ describe('parse', function () {
     });
 
     it('name', function () {
+        var res = doctrine.parse('/** @name thingName#name */', { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'name');
+        res.tags[0].should.have.property('name', 'thingName#name');
+    });
+
+    it('name', function () {
+        var res = doctrine.parse('/** @name thingName~name */', { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'name');
+        res.tags[0].should.have.property('name', 'thingName~name');
+    });
+
+    it('name', function () {
         var res = doctrine.parse('/** @name {thing} thingName.name */', { unwrap: true });
         // name does not accept type
         res.tags.should.have.length(0);


### PR DESCRIPTION
As described here http://usejsdoc.org/about-namepaths.html not only a dot can be used to describe members. Also a # and ~ syntax is possible.
This is currently not parsed correctly and fixed with this commit.
