### PR TITLE
Fix crash on @param with invalid type in sloppy mode.

### DIFF
--- a/doctrine.js
+++ b/doctrine.js
@@ -1779,7 +1779,7 @@
                         this._tag.name = assign[0];
 
                         // convert to an optional type
-                        if (this._tag.type.type !== 'OptionalType') {
+                        if (this._tag.type && this._tag.type.type !== 'OptionalType') {
                             this._tag.type = {
                                 type: 'OptionalType',
                                 expression: this._tag.type

--- a/test/parse.js
+++ b/test/parse.js
@@ -1759,6 +1759,11 @@ describe('recovery tests', function() {
 		var res = doctrine.parse("@param {Function(DOMNode)}",
                                          { recoverable: true });
         });
+
+	it ('should not crash on bad type in @param in sloppy mode', function() {
+		var res = doctrine.parse("@param {int[} [x]",
+                                         { sloppy: true });
+        });
 });
 
 describe('exported Syntax', function() {


### PR DESCRIPTION
Partial fix for https://github.com/Constellation/doctrine/issues/92: it no longer crashes, but the malformed type is still not recorded as an error.
