### PR TITLE
Fix line numbers in the presence of Windows line endings.

### DIFF
--- a/doctrine.js
+++ b/doctrine.js
@@ -1472,7 +1472,7 @@
         function advance() {
             var ch = source[index];
             index += 1;
-            if (isLineTerminator(ch)) {
+            if (isLineTerminator(ch) && !(ch === '\r' && source[index] === '\n')) {
                 lineNumber += 1;
             }
             return ch;
@@ -1496,7 +1496,7 @@
             waiting = false;
             while (last < length) {
                 ch = source[last];
-                if (isLineTerminator(ch)) {
+                if (isLineTerminator(ch) && !(ch === '\r' && source[last + 1] === '\n')) {
                     lineNumber += 1;
                     waiting = true;
                 } else if (waiting) {

--- a/test/parse.js
+++ b/test/parse.js
@@ -1589,6 +1589,25 @@ describe('optional params', function() {
         res.tags[1].should.have.property('lineNumber', 2);
         res.tags[2].should.have.property('lineNumber', 4);
     });
+
+    it('should handle \\r\\n line endings correctly', function() {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * @param {string} foo",
+                " * @returns {string}",
+                " *",
+                " * @example",
+                " * f('blah'); // => undefined",
+                " */"
+            ].join('\r\n'),
+            { unwrap: true, lineNumbers: true }
+        );
+
+        res.tags[0].should.have.property('lineNumber', 1);
+        res.tags[1].should.have.property('lineNumber', 2);
+        res.tags[2].should.have.property('lineNumber', 4);
+    });
 });
 
 describe('recovery tests', function() {


### PR DESCRIPTION
Previously, `\r\n` line endings were double-counted.
