### PR TITLE
fixed doctrine.js path to fix the demo page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -10,7 +10,7 @@
 
     <script type="text/javascript" charset="utf-8" src="../javascripts/jquery.min.js"></script>
     <script type="text/javascript" charset="utf-8" src="../javascripts/json2.js"></script>
-    <script type="text/javascript" charset="utf-8" src="https://rawgithub.com/Constellation/doctrine/master/doctrine.js"></script>
+    <script type="text/javascript" charset="utf-8" src="https://rawgithub.com/Constellation/doctrine/master/lib/doctrine.js"></script>
     <script type="text/javascript" charset="utf-8">
     $(function() {
       var code = [
@@ -60,6 +60,6 @@
         <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
       </footer>
     </div>
-    <script src="javascripts/scale.fix.js"></script>
+    <script src="../javascripts/scale.fix.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Currently the demo page show the following error: `ReferenceError: doctrine is not defined`, because the script url leads to 404.
