### PR TITLE
Add support for tags in namepaths [fixes #90]

### DIFF
--- a/lib/doctrine.js
+++ b/lib/doctrine.js
@@ -314,6 +314,14 @@
             name += scanIdentifier(last);
 
             if (allowNestedParams) {
+                if (source.charCodeAt(index) === 0x3A /* ':' */ && (
+                        name === 'module' ||
+                        name === 'external' ||
+                        name === 'event')) {
+                    name += advance();
+                    name += scanIdentifier(last);
+
+                }
                 while (source.charCodeAt(index) === 0x2E  /* '.' */ ||
                         source.charCodeAt(index) === 0x23  /* '#' */ ||
                         source.charCodeAt(index) === 0x7E  /* '~' */) {

--- a/lib/typed.js
+++ b/lib/typed.js
@@ -643,9 +643,26 @@
         };
     }
 
+    // NameExpression :=
+    //    Identifier
+    //  | TagIdentifier ':' Identifier
+    //
+    // Tag identifier is one of "module", "external" or "event"
+    // Identifier is the same as Token.NAME, including any dots, something like
+    // namespace.module.MyClass
     function parseNameExpression() {
         var name = value;
         expect(Token.NAME);
+
+        if (token === Token.COLON && (
+                name === 'module' ||
+                name === 'external' ||
+                name === 'event')) {
+            consume(Token.COLON);
+            name += ':' + value;
+            expect(Token.NAME);
+        }
+
         return {
             type: Syntax.NameExpression,
             name: name

--- a/test/parse.js
+++ b/test/parse.js
@@ -2161,4 +2161,51 @@ describe('function', function () {
     });
 });
 
+describe('tagged namepaths', function () {
+    it ('recognize module:', function () {
+        var res = doctrine.parse(
+            [
+                "@alias module:Foo.bar"
+            ].join('\n'), {});
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'alias');
+        res.tags[0].should.have.property('name', 'module:Foo.bar');
+        res.tags[0].should.have.property('description', null);
+    });
+
+    it ('recognize external:', function () {
+        var res = doctrine.parse(
+            [
+                "@param {external:Foo.bar} baz description"
+            ].join('\n'), {});
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'param');
+         res.tags[0].type.should.eql({
+             "name": "external:Foo.bar",
+             "type": "NameExpression"
+         });
+        res.tags[0].should.have.property('name', 'baz');
+        res.tags[0].should.have.property('description', 'description');
+    });
+
+    it ('recognize event:', function () {
+        var res = doctrine.parse(
+            [
+                "@function event:Foo.bar"
+            ].join('\n'), {});
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'function');
+        res.tags[0].should.have.property('name', 'event:Foo.bar');
+        res.tags[0].should.have.property('description', null);
+    });
+
+    it ('invalid bogus:', function () {
+        var res = doctrine.parse(
+            [
+                "@method bogus:Foo.bar"
+            ].join('\n'), {});
+        res.tags.should.have.length(0);
+    });
+});
+
 /* vim: set sw=4 ts=4 et tw=80 : */


### PR DESCRIPTION
This adds support for the "module", "external" and "event" tags in JSDoc.

For the original issue see #90.
