### PR TITLE
Parse array default syntax

### DIFF
--- a/lib/doctrine.js
+++ b/lib/doctrine.js
@@ -337,13 +337,21 @@
             }
 
             if (useBrackets) {
+
+
                 // do we have a default value for this?
                 if (source.charCodeAt(index) === 0x3D  /* '=' */) {
-
                     // consume the '='' symbol
                     name += advance();
+                    var bracketDepth = 1;
                     // scan in the default value
-                    while (index < last && source.charCodeAt(index) !== 0x5D  /* ']' */) {
+                    while (index < last) {
+                        if (source.charCodeAt(index) === 0x5B /* '[' */) {
+                            bracketDepth++;
+                        } else if (source.charCodeAt(index) === 0x5D  /* ']' */ &&
+                            --bracketDepth === 0) {
+                            break;
+                        }
                         name += advance();
                     }
                 }

--- a/test/parse.js
+++ b/test/parse.js
@@ -1921,6 +1921,28 @@ describe('optional params', function() {
         });
     });
 
+    it('default array', function() {
+        doctrine.parse(
+            ["/**", " * @param {String} [val=['foo']] some description", " */"].join('\n'),
+            { unwrap: true, sloppy: true}
+        ).should.eql({
+            "description": "",
+            "tags": [{
+                "title": "param",
+                "description": "some description",
+                "type": {
+                    "type": "OptionalType",
+                    "expression": {
+                        "type": "NameExpression",
+                        "name": "String"
+                    }
+                },
+                "name": "val",
+                "default": "['foo']"
+            }]
+        });
+    });
+
     it('line numbers', function() {
         var res = doctrine.parse(
             [


### PR DESCRIPTION
Fixes #133

this allows the code

    @param {Array} [foo=[1]] to properly be parsed

It does this by keeping track of bracket depth in the name parsing.