### PR TITLE
Failing test for quoted params

### DIFF
--- a/test/parse.js
+++ b/test/parse.js
@@ -379,6 +379,13 @@ describe('parse', function () {
         res.tags[0].should.have.property('name', 'thingName~name');
     });
 
+    it('quoted name with colon character', function () {
+        var res = doctrine.parse('/** @name "thingName:name" */', { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'name');
+        res.tags[0].should.have.property('name', 'thingName:name');
+    });
+
     it('name', function () {
         var res = doctrine.parse('/** @name {thing} thingName.name */', { unwrap: true });
         // name does not accept type


### PR DESCRIPTION
Demonstrating lack of support for names with quoted special characters.

This behavior, as far as I can tell, deviates from [JSDoc's page on namepaths](http://usejsdoc.org/about-namepaths.html).

I think that this would be fixed in parseName()?
