### PR TITLE
Update: Add support for BooleanLiteralType

### DIFF
--- a/lib/typed.js
+++ b/lib/typed.js
@@ -43,7 +43,8 @@
         NameExpression: 'NameExpression',
         TypeApplication: 'TypeApplication',
         StringLiteralType: 'StringLiteralType',
-        NumericLiteralType: 'NumericLiteralType'
+        NumericLiteralType: 'NumericLiteralType',
+        BooleanLiteralType: 'BooleanLiteralType'
     };
 
     Token = {
@@ -883,6 +884,14 @@
                 };
             }
 
+            if (value === 'true' || value === 'false') {
+                consume(Token.NAME);
+                return {
+                    type: Syntax.BooleanLiteralType,
+                    value: value === 'true'
+                };
+            }
+
             context = Context.save();
             if (value === 'function') {
                 try {
@@ -1245,6 +1254,10 @@
             break;
 
         case Syntax.NumericLiteralType:
+            result = String(node.value);
+            break;
+
+        case Syntax.BooleanLiteralType:
             result = String(node.value);
             break;
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -1246,6 +1246,74 @@ describe('parse', function () {
         res.tags[1].type.elements.should.containEql({type: 'StringLiteralType', value: 'private'});
         res.tags[1].type.elements.should.containEql({type: 'StringLiteralType', value: 'protected'});
     });
+
+    it('numeric literal property', function () {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * @typedef {Object} comment",
+                " * @property {(-42|1.5|0)} access",
+                "*/"
+            ].join('\n'), { unwrap: true });
+
+        res.tags.should.have.length(2);
+        res.tags[1].should.have.property('title', 'property');
+        res.tags[1].should.have.property('name', 'access');
+        res.tags[1].type.should.have.property('type', 'UnionType');
+        res.tags[1].type.elements.should.have.length(3);
+        res.tags[1].type.elements.should.containEql({type: 'NumericLiteralType', value: -42});
+        res.tags[1].type.elements.should.containEql({type: 'NumericLiteralType', value: 1.5});
+        res.tags[1].type.elements.should.containEql({type: 'NumericLiteralType', value: 0});
+    });
+
+    it('boolean literal property', function () {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * @typedef {Object} comment",
+                " * @property {(true|false)} access",
+                "*/"
+            ].join('\n'), { unwrap: true });
+
+        res.tags.should.have.length(2);
+        res.tags[1].should.have.property('title', 'property');
+        res.tags[1].should.have.property('name', 'access');
+        res.tags[1].type.should.have.property('type', 'UnionType');
+        res.tags[1].type.elements.should.have.length(2);
+        res.tags[1].type.elements.should.containEql({type: 'BooleanLiteralType', value: true});
+        res.tags[1].type.elements.should.containEql({type: 'BooleanLiteralType', value: false});
+    });
+
+    it('complex union with literal types', function () {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * @typedef {({ok: true, data: string} | {ok: false, error: Error})} Result",
+                "*/"
+            ].join('\n'), { unwrap: true });
+
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'typedef');
+        res.tags[0].should.have.property('name', 'Result');
+        res.tags[0].type.should.have.property('type', 'UnionType');
+        res.tags[0].type.elements.should.have.length(2);
+
+        var e0 = res.tags[0].type.elements[0];
+        e0.should.have.property('type', 'RecordType');
+        e0.fields.should.have.length(2);
+        e0.fields.should.containEql({type: 'FieldType', key: 'ok',
+          value: {type: 'BooleanLiteralType', value: true}});
+        e0.fields.should.containEql({type: 'FieldType', key: 'data',
+          value: {type: 'NameExpression', name: 'string'}});
+
+        var e1 = res.tags[0].type.elements[1];
+        e1.should.have.property('type', 'RecordType');
+        e1.fields.should.have.length(2);
+        e1.fields.should.containEql({type: 'FieldType', key: 'ok',
+          value: {type: 'BooleanLiteralType', value: false}});
+        e1.fields.should.containEql({type: 'FieldType', key: 'error',
+          value: {type: 'NameExpression', name: 'Error'}});
+    });
 });
 
 describe('parseType', function () {
@@ -1783,6 +1851,20 @@ describe('parseType', function () {
         type.should.eql({
             type: 'NumericLiteralType',
             value: -142.42
+        });
+    });
+
+    it('boolean literal type', function () {
+        var type;
+        type = doctrine.parseType('true');
+        type.should.eql({
+            type: 'BooleanLiteralType',
+            value: true
+        });
+        type = doctrine.parseType('false');
+        type.should.eql({
+            type: 'BooleanLiteralType',
+            value: false
         });
     });
 
@@ -2438,6 +2520,7 @@ describe('exported Syntax', function() {
             VoidLiteral: 'VoidLiteral',
             UnionType: 'UnionType',
             ArrayType: 'ArrayType',
+            BooleanLiteralType: 'BooleanLiteralType',
             RecordType: 'RecordType',
             FieldType: 'FieldType',
             FunctionType: 'FunctionType',

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -117,8 +117,19 @@ describe('literals', function() {
     it('NumericLiteralType', function () {
         doctrine.type.stringify({
             type: doctrine.Syntax.NumericLiteralType,
-            value: '-142.35'
+            value: -142.35
         }).should.equal('-142.35');
+    });
+
+    it('BooleanLiteralType', function () {
+        doctrine.type.stringify({
+            type: doctrine.Syntax.BooleanLiteralType,
+            value: true
+        }).should.equal('true');
+        doctrine.type.stringify({
+            type: doctrine.Syntax.BooleanLiteralType,
+            value: false
+        }).should.equal('false');
     });
 });
 


### PR DESCRIPTION
Both Flow and TypeScript (2.0) support boolean literals as types.

These are mostly used with unions as in:

```js
type Result = {
  ok: true,
  value: string,
} | {
  ok: false,
}
```