### PR TITLE
Docs: Add options to demo, fix links on home page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -11,54 +11,75 @@
     <script type="text/javascript" charset="utf-8" src="../javascripts/jquery.min.js"></script>
     <script type="text/javascript" charset="utf-8" src="../javascripts/json2.js"></script>
     <script type="text/javascript" charset="utf-8" src="../javascripts/doctrine.js"></script>
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/styles/default.min.css">
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/highlight.min.js"></script>
     <script type="text/javascript" charset="utf-8">
     $(function() {
+      var lineNumbers = false;
+      var sloppy = false;
+      var recoverable = false;
+      $('input#lineNumbers').change(function (ev) {
+        lineNumbers = !!$(this).attr('checked');
+        updateDocumentation();
+      });
+      $('input#sloppy').change(function (ev) {
+        sloppy = !!$(this).attr('checked');
+        updateDocumentation();
+      });
+      $('input#recoverable').change(function (ev) {
+        recoverable = !!$(this).attr('checked');
+        updateDocumentation();
+      });
       var code = [
         '@constructor',
         '@param {(jQuerySelector|Element|Object|Array.<Element>|jQuery|string|function())=} arg1',
         '@param {(Element|Object|Document|Object.<string, (string|function(!jQuery.event=))>)=} arg2',
         '@return {!jQuery}',
       ].join('\n');
-      $('#code').val(code).on('keyup paste change', function (ev) {
-        var comment = '/**\n' + $(this).val() + '\n*/';
+      $('#code').val(code).on('keyup paste change', updateDocumentation).change();
+      function updateDocumentation(ev) {
+        var comment = '/**\n' + $('#code').val() + '\n*/';
         try {
-          var result = doctrine.parse(comment, { unwrap : true });
+          var result = doctrine.parse(comment, { unwrap : true, sloppy: sloppy, lineNumbers: lineNumbers, recoverable: recoverable });
           $('#result').text(JSON.stringify(result, null, 4));
+          hljs.highlightBlock($('#result')[0]);
         } catch (e) {
           $('#result').text(e.toString());
         }
-      }).change();
+      }
     });
     </script>
+    <style>
+    #code {
+        font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
+        font-size:13px;
+        width:100%;
+        height:100px;
+        box-sizing: border-box;
+        padding: 5px;
+    }
+    </style>
     <title>Doctrine</title>
   </head>
 
   <body>
     <div class="wrapper">
-      <header>
-        <h1>Doctrine</h1>
-        <p>JSDoc parser</p>
-        <p class="view"><a href="https://github.com/Constellation/doctrine">View the Project on GitHub <small>Constellation/doctrine</small></a></p>
-        <ul>
-          <li><a href="https://github.com/Constellation/doctrine/zipball/master">Download <strong>ZIP File</strong></a></li>
-          <li><a href="https://github.com/Constellation/doctrine/tarball/master">Download <strong>TAR Ball</strong></a></li>
-          <li><a href="https://github.com/Constellation/doctrine">View On <strong>GitHub</strong></a></li>
-        </ul>
-      </header>
-      <section>
-        <h2>Doctrine Demo</h2>
-        <p>doctrine (<a href="http://github.com/Constellation/doctrine">doctrine</a>) is JSDoc parser.</p>
+        <h2>Doctrine</h2>
+        <div class='nav'><a href='../'>Home</a><span>Demo</span></div>
+        
         <p>see <a href="https://developers.google.com/closure/compiler/docs/js-for-compiler">samples in Google Closure Compiler</a></p>
 
-        <strong>/**<strong>
-        <textarea id='code' style="width:100%;height:100px;"></textarea>
-        <strong>*/<strong>
-        <pre id='result' style="font-size:50%"><code></code></pre>
-      </section>
-      <footer>
-        <p>This project is maintained by <a href="https://github.com/Constellation">Constellation</a></p>
-        <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
-      </footer>
+        <textarea id='code'></textarea>
+        <div>
+          <input type='checkbox' id='sloppy' /> <label for='sloppy'>sloppy</label>
+        </div>
+        <div>
+          <input type='checkbox' id='lineNumbers' /> <label for='lineNumbers'>lineNumbers</label>
+        </div>
+        <div>
+          <input type='checkbox' id='recoverable' /> <label for='recoverable'>recoverable</label>
+        </div>
+        <pre id='result'><code></code></pre>
     </div>
     <script src="../javascripts/scale.fix.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -11,23 +11,31 @@
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/styles/default.min.css">
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/highlight.min.js"></script>
+    <script>hljs.initHighlightingOnLoad();</script>
   </head>
   <body>
     <div class="wrapper">
       <header>
         <h1>Doctrine</h1>
-        <p>JSDoc parser</p>
-        <p class="view"><a href="https://github.com/Constellation/doctrine">View the Project on GitHub <small>Constellation/doctrine</small></a></p>
+        <div class='nav'><span>Home</span><a href='./demo'>Demo</a></div>
+        <p class="view"><a href="https://github.com/eslint/doctrine">View the Project on GitHub <small>eslint/doctrine</small></a></p>
+        <p><a href="./demo/index.html">Demo</a></p>
         <ul>
-          <li><a href="https://github.com/Constellation/doctrine/zipball/master">Download <strong>ZIP File</strong></a></li>
-          <li><a href="https://github.com/Constellation/doctrine/tarball/master">Download <strong>TAR Ball</strong></a></li>
-          <li><a href="https://github.com/Constellation/doctrine">View On <strong>GitHub</strong></a></li>
+          <li><a href="https://github.com/eslint/doctrine/zipball/master">Download <strong>ZIP File</strong></a></li>
+          <li><a href="https://github.com/eslint/doctrine/tarball/master">Download <strong>TAR Ball</strong></a></li>
+          <li><a href="https://github.com/eslint/doctrine">View On <strong>GitHub</strong></a></li>
         </ul>
       </header>
       <section>
-        <p>doctrine (<a href="http://github.com/Constellation/doctrine">doctrine</a>) is JSDoc parser.</p>
+        <p>doctrine (<a href="http://github.com/eslint/doctrine">doctrine</a>) is a JSDoc parser.</p>
 
-<p>It is now used by content assist system of <a href="http://www.eclipse.org/orion/">Eclipse Orion</a> (<a href="http://planetorion.org/news/2012/10/orion-1-0-release/">detail</a>)</p>
+        <p>It's used by</p>
+        <ul>
+          <li><a href="http://www.eclipse.org/orion/">Eclipse Orion</a>'s content assist system (<a href="http://planetorion.org/news/2012/10/orion-1-0-release/">detail</a>)</li>
+          <li><a href="http://eslint.org/">eslint</a>'s <a href="http://eslint.org/docs/rules/valid-jsdoc">valid-jsdoc rule</a></li>
+        </ul>
 
 <p>Doctrine can be used in a web browser:</p>
 
@@ -39,7 +47,7 @@
 
 <p>simple example:</p>
 
-<pre><code>doctrine.parse(
+<pre><code class='hljs javascript'>doctrine.parse(
     [
         "/**",
         " * This function comment is parsed by doctrine",
@@ -75,7 +83,6 @@
 }
 </code></pre>
 
-<p>see <a href="http://constellation.github.com/doctrine/demo/index.html">demo page</a> more detail.</p>
 
 <h3>License</h3>
 
@@ -106,7 +113,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 
 <h4>esprima</h4>
 
-<p>some of functions is derived from esprima</p>
+<p>some the functions are derived from esprima</p>
 
 <p>Copyright (C) 2012, 2011 <a href="http://ariya.ofilabs.com/about">Ariya Hidayat</a>
  (twitter: <a href="http://twitter.com/ariyahidayat">@ariyahidayat</a>) and other contributors.</p>
@@ -133,7 +140,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 
 <h4>closure-compiler</h4>
 
-<p>some of extensions is derived from closure-compiler</p>
+<p>some extensions are derived from closure-compiler</p>
 
 <p>Apache License
 Version 2.0, January 2004

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -1,8 +1,30 @@
 @import url(https://fonts.googleapis.com/css?family=Lato:300italic,700italic,300,700);
 
+.nav span,
+.nav a {
+  width: 135px;
+  background: #eee;
+  border: 1px solid #aaa;
+  display: inline-block;
+  box-sizing: border-box;
+  padding: 5px 10px;
+  margin-bottom:20px;
+  font-weight:bold;
+}
+.nav a {
+  font-weight:normal;
+  background: #fff;
+  border: 0;
+  border-bottom: 1px solid #aaa;
+  display: inline-block;
+  box-sizing: border-box;
+  padding: 5px 10px;
+  margin-bottom:20px;
+}
+
 body {
   padding:50px;
-  font:14px/1.5 Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font:18px/1.5 Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
   color:#777;
   font-weight:300;
 }
@@ -65,9 +87,9 @@ code, pre {
 
 pre {
   padding:8px 15px;
-  background: #f8f8f8;  
+  background: #F0F0F0;  
   border-radius:5px;
-  border:1px solid #e5e5e5;
+  border:1px solid #666;
   overflow-x: auto;
 }
 


### PR DESCRIPTION
This isn't a full redesign: it's the minimal amount of change that I could do to make the demo more useful for developers and the homepage more current, without making major design changes.

Fixes:

* Grammar on homepage & demo
* Many links that go to the old Constellation demo

Improvements:

* Source highlighting for examples and demo output

Additions:

* Toggles for sloppy, lineNumbers, and recoverable in the demo

Demo:

![2016-12-09 at 3 24 pm](https://cloud.githubusercontent.com/assets/32314/21063435/9aad3612-be23-11e6-8f52-5539fcca695b.png)
