### PR TITLE
Add intersection type support.

### DIFF
--- a/lib/typed.js
+++ b/lib/typed.js
@@ -3,6 +3,7 @@
  * @author Yusuke Suzuki <utatane.tea@gmail.com>
  * @author Dan Tao <daniel.tao@gmail.com>
  * @author Andrew Eisenberg <andrew@eisenberg.as>
+ * @author Joel Day <joelday@gmail.com>
  */
 
 // "typed", the Type Expression Parser for doctrine.
@@ -31,6 +32,7 @@
         UndefinedLiteral: 'UndefinedLiteral',
         VoidLiteral: 'VoidLiteral',
         UnionType: 'UnionType',
+        IntersectionType: 'IntersectionType',
         ArrayType: 'ArrayType',
         RecordType: 'RecordType',
         FieldType: 'FieldType',
@@ -57,23 +59,24 @@
         RPAREN: 6,     // )
         LBRACE: 7,     // {
         RBRACE: 8,     // }
-        LBRACK: 9,    // [
+        LBRACK: 9,     // [
         RBRACK: 10,    // ]
         COMMA: 11,     // ,
         COLON: 12,     // :
         STAR: 13,      // *
         PIPE: 14,      // |
-        QUESTION: 15,  // ?
-        BANG: 16,      // !
-        EQUAL: 17,     // =
-        NAME: 18,      // name token
-        STRING: 19,    // string
-        NUMBER: 20,    // number
-        EOF: 21
+        AMP: 15,       // &
+        QUESTION: 16,  // ?
+        BANG: 17,      // !
+        EQUAL: 18,     // =
+        NAME: 19,      // name token
+        STRING: 20,    // string
+        NUMBER: 21,    // number
+        EOF: 22
     };
 
     function isTypeName(ch) {
-        return '><(){}[],:*|?!='.indexOf(String.fromCharCode(ch)) === -1 && !esutils.code.isWhiteSpace(ch) && !esutils.code.isLineTerminator(ch);
+        return '><(){}[],:*|&?!='.indexOf(String.fromCharCode(ch)) === -1 && !esutils.code.isWhiteSpace(ch) && !esutils.code.isLineTerminator(ch);
     }
 
     function Context(previous, index, token, value) {
@@ -450,6 +453,11 @@
             token = Token.PIPE;
             return token;
 
+        case 0x26:  /* '&' */
+            advance();
+            token = Token.AMP;
+            return token;
+
         case 0x3F:  /* '?' */
             advance();
             token = Token.QUESTION;
@@ -507,9 +515,22 @@
     // NonemptyTypeUnionList :=
     //     TypeExpression
     //   | TypeExpression '|' NonemptyTypeUnionList
-    function parseUnionType() {
-        var elements;
-        consume(Token.LPAREN, 'UnionType should start with (');
+    //
+    // IntersectionType := '(' TypeIntersectionList ')'
+    //
+    // TypeIntersectionList :=
+    //     <<empty>>
+    //   | NonemptyTypeIntersectionList
+    //
+    // NonemptyTypeIntersectionList :=
+    //     TypeExpression
+    //   | TypeExpression '&' NonemptyTypeIntersectionList
+    //
+    // Type is assumed to be UnionType if it is empty.
+    function parseUnionOrIntersectionType() {
+        var elements, typeToken;
+
+        consume(Token.LPAREN, 'UnionType or IntersectionType should start with (');
         elements = [];
         if (token !== Token.RPAREN) {
             while (true) {
@@ -517,12 +538,17 @@
                 if (token === Token.RPAREN) {
                     break;
                 }
-                expect(Token.PIPE);
+
+                if (token === Token.PIPE || token === Token.AMP) {
+                    typeToken = token;
+                }
+
+                expect(typeToken);
             }
         }
-        consume(Token.RPAREN, 'UnionType should end with )');
+        consume(Token.RPAREN, 'UnionType or IntersectionType should end with )');
         return {
-            type: Syntax.UnionType,
+            type: typeToken === Token.AMP ? Syntax.IntersectionType : Syntax.UnionType,
             elements: elements
         };
     }
@@ -861,7 +887,7 @@
             };
 
         case Token.LPAREN:
-            return parseUnionType();
+            return parseUnionOrIntersectionType();
 
         case Token.LBRACK:
             return parseArrayType();
@@ -936,8 +962,8 @@
         if (token === Token.QUESTION) {
             consume(Token.QUESTION);
             if (token === Token.COMMA || token === Token.EQUAL || token === Token.RBRACE ||
-                    token === Token.RPAREN || token === Token.PIPE || token === Token.EOF ||
-                    token === Token.RBRACK || token === Token.GT) {
+                    token === Token.RPAREN || token === Token.PIPE || token === Token.AMP ||
+                    token === Token.EOF || token === Token.RBRACK || token === Token.GT) {
                 return {
                     type: Syntax.NullableLiteral
                 };
@@ -1002,26 +1028,31 @@
     //   { number | string }
     // If strict to ES4, we should write it as
     //   { (number|string) }
+    //
+    // Using the same logic for intersection types
     function parseTop() {
-        var expr, elements;
+        var expr, elements, typeToken;
 
         expr = parseTypeExpression();
-        if (token !== Token.PIPE) {
+        if (token !== Token.PIPE && token !== Token.AMP) {
             return expr;
         }
 
         elements = [expr];
-        consume(Token.PIPE);
+
+        typeToken = token === Token.AMP ? Token.AMP : Token.PIPE;
+
+        consume(typeToken);
         while (true) {
             elements.push(parseTypeExpression());
-            if (token !== Token.PIPE) {
+            if (token !== typeToken) {
                 break;
             }
-            consume(Token.PIPE);
+            consume(typeToken);
         }
 
         return {
-            type: Syntax.UnionType,
+            type: typeToken === Token.AMP ? Syntax.IntersectionType : Syntax.UnionType,
             elements: elements
         };
     }
@@ -1134,6 +1165,25 @@
                 result += stringifyImpl(node.elements[i], compact);
                 if ((i + 1) !== iz) {
                     result += '|';
+                }
+            }
+
+            if (!topLevel) {
+                result += ')';
+            }
+            break;
+
+        case Syntax.IntersectionType:
+            if (!topLevel) {
+                result = '(';
+            } else {
+                result = '';
+            }
+
+            for (i = 0, iz = node.elements.length; i < iz; ++i) {
+                result += stringifyImpl(node.elements[i], compact);
+                if ((i + 1) !== iz) {
+                    result += '&';
                 }
             }
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -1,6 +1,7 @@
 /*
  * @fileoverview Main Doctrine object
  * @author Yusuke Suzuki <utatane.tea@gmail.com>
+ * @author Joel Day <joelday@gmail.com>
  */
 /*global require describe it*/
 /*jslint node:true */
@@ -2759,6 +2760,7 @@ describe('exported Syntax', function() {
             UndefinedLiteral: 'UndefinedLiteral',
             VoidLiteral: 'VoidLiteral',
             UnionType: 'UnionType',
+            IntersectionType: 'IntersectionType',
             ArrayType: 'ArrayType',
             BooleanLiteralType: 'BooleanLiteralType',
             RecordType: 'RecordType',

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -1,6 +1,7 @@
 /*
  * @fileoverview Main Doctrine object
  * @author Yusuke Suzuki <utatane.tea@gmail.com>
+ * @author Joel Day <joelday@gmail.com>
  */
 /*global require describe it*/
 /*jslint node:true */
@@ -53,10 +54,14 @@ describe('stringify', function () {
     testStringify("()");
     testStringify("(String|Number)");
 
+    // intersection types
+    testStringify("(String&Number)");
+
     // Arrays
     testStringify("[String]");
     testStringify("[String,Number]");
     testStringify("[(String|Number)]");
+    testStringify("[(String&Number)]");
 
     // Record types
     testStringify("{a}");
@@ -67,6 +72,9 @@ describe('stringify', function () {
     testStringify("{a:(String|Number),b,c:Array.<String>}");
     testStringify("...{a:(String|Number),b,c:Array.<String>}");
     testStringify("{a:(String|Number),b,c:Array.<String>}=");
+    testStringify("{a:(String&Number),b,c:Array.<String>}");
+    testStringify("...{a:(String&Number),b,c:Array.<String>}");
+    testStringify("{a:(String&Number),b,c:Array.<String>}=");
 
     // fn types
     testStringify("function(a)");
@@ -76,6 +84,10 @@ describe('stringify', function () {
     testStringify("function(a:number,callback:function(a:Array.<(String|Number|Object)>):boolean):String");
     testStringify("function(a:(string|number),this:string,new:true):function():number");
     testStringify("function(a:(string|number),this:string,new:true):function(a:function(val):result):number");
+    testStringify("function(a:number,b:Array.<(String&Number&Object)>):String");
+    testStringify("function(a:number,callback:function(a:Array.<(String&Number&Object)>):boolean):String");
+    testStringify("function(a:(string&number),this:string,new:true):function():number");
+    testStringify("function(a:(string&number),this:string,new:true):function(a:function(val):result):number");
 
     // literal types
     testStringify('"Hello, World!"');
@@ -249,6 +261,40 @@ describe('Expression', function () {
                 name: 'Number'
             }]
         }, { topLevel: true }).should.equal('String|Number');
+    });
+
+    it('IntersectionType', function () {
+        // Even though a single element within parens will be parsed as a UnionType,
+        // the stringified result for this node should still be the same.
+        doctrine.type.stringify({
+            type: doctrine.Syntax.IntersectionType,
+            elements: [{
+                type: doctrine.Syntax.NameExpression,
+                name: 'String'
+            }]
+        }).should.equal('(String)');
+
+        doctrine.type.stringify({
+            type: doctrine.Syntax.IntersectionType,
+            elements: [{
+                type: doctrine.Syntax.NameExpression,
+                name: 'String'
+            }, {
+                type: doctrine.Syntax.NameExpression,
+                name: 'Number'
+            }]
+        }).should.equal('(String&Number)');
+
+        doctrine.type.stringify({
+            type: doctrine.Syntax.IntersectionType,
+            elements: [{
+                type: doctrine.Syntax.NameExpression,
+                name: 'String'
+            }, {
+                type: doctrine.Syntax.NameExpression,
+                name: 'Number'
+            }]
+        }, { topLevel: true }).should.equal('String&Number');
     });
 
     it('RestType', function () {


### PR DESCRIPTION
Implements #183.

Adds a syntax member, ampersand token and new parser logic to distinguish between UnionType and IntersectionType for both paren and top level declarations.

Thanks!