### PR TITLE
[BugFix] Incorrect behavior when arrow functions are used as default values

### DIFF
--- a/lib/doctrine.js
+++ b/lib/doctrine.js
@@ -519,8 +519,8 @@
                         // extract the default value if there is one
                         // example: @param {string} [somebody=John Doe] description
                         assign = name.substring(1, name.length - 1).split('=');
-                        if (assign[1]) {
-                            this._tag['default'] = assign[1];
+                        if (assign.length > 1) {
+                            this._tag['default'] = assign.slice(1).join('=');
                         }
                         this._tag.name = assign[0];
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -2171,6 +2171,28 @@ describe('optional params', function() {
         });
     });
 
+    it('default arrow functions', function() {
+        doctrine.parse(
+            ["/**", " * @param {Function} [fn=()=>{}] some description", " */"].join('\n'),
+            {unwrap: true, sloppy: true}
+        ).should.eql({
+            description: "",
+            tags: [{
+                "title": "param",
+                "description": "some description",
+                "type": {
+                    "type": "OptionalType",
+                    "expression": {
+                        "type": "NameExpression",
+                        "name": "Function"
+                    }
+                },
+                "name": "fn",
+                "default": "()=>{}"
+            }]
+        });
+    });
+
     it('line numbers', function() {
         var res = doctrine.parse(
             [


### PR DESCRIPTION
When arrow functions are used as default values in arguments, the output is currently incorrect. 

Example:

````
/**
* @param {String} [x=()=>{}]
*/
function hello() {}
````

Expected default value in generated documentation: `() => {}`
Current default value in generated documentation: `()`