### PR TITLE
Update: support node ranges (fixes #89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The primary method is `parse()`, which accepts two arguments: the JSDoc comment 
 * `recoverable` - set to `true` to keep parsing even when syntax errors occur. Default: `false`.
 * `sloppy` - set to `true` to allow optional parameters to be specified in brackets (`@param {string} [foo]`). Default: `false`.
 * `lineNumbers` - set to `true` to add `lineNumber` to each node, specifying the line on which the node is found in the source. Default: `false`.
+* `range` - set to `true` to add `range` to each node, specifying the start and end index of the node in the original comment. Default: `false`.
 
 Here's a simple example:
 

--- a/lib/typed.js
+++ b/lib/typed.js
@@ -19,7 +19,9 @@
         token,
         value,
         esutils,
-        utility;
+        utility,
+        rangeOffset,
+        addRange;
 
     esutils = require('esutils');
     utility = require('./utility');
@@ -93,6 +95,13 @@
     Context.save = function () {
         return new Context(previous, index, token, value);
     };
+
+    function maybeAddRange(node, range) {
+        if (addRange) {
+            node.range = [range[0] + rangeOffset, range[1] + rangeOffset];
+        }
+        return node;
+    }
 
     function advance() {
         var ch = source.charAt(index);
@@ -508,7 +517,7 @@
     //     TypeExpression
     //   | TypeExpression '|' NonemptyTypeUnionList
     function parseUnionType() {
-        var elements;
+        var elements, startIndex = index - 1;
         consume(Token.LPAREN, 'UnionType should start with (');
         elements = [];
         if (token !== Token.RPAREN) {
@@ -521,10 +530,10 @@
             }
         }
         consume(Token.RPAREN, 'UnionType should end with )');
-        return {
+        return maybeAddRange({
             type: Syntax.UnionType,
             elements: elements
-        };
+        }, [startIndex, previous]);
     }
 
     // ArrayType := '[' ElementTypeList ']'
@@ -535,16 +544,17 @@
     //  | '...' TypeExpression
     //  | TypeExpression ',' ElementTypeList
     function parseArrayType() {
-        var elements;
+        var elements, startIndex = index - 1, restStartIndex;
         consume(Token.LBRACK, 'ArrayType should start with [');
         elements = [];
         while (token !== Token.RBRACK) {
             if (token === Token.REST) {
+                restStartIndex = index - 3;
                 consume(Token.REST);
-                elements.push({
+                elements.push(maybeAddRange({
                     type: Syntax.RestType,
                     expression: parseTypeExpression()
-                });
+                }, [restStartIndex, previous]));
                 break;
             } else {
                 elements.push(parseTypeExpression());
@@ -554,10 +564,10 @@
             }
         }
         expect(Token.RBRACK);
-        return {
+        return maybeAddRange({
             type: Syntax.ArrayType,
             elements: elements
-        };
+        }, [startIndex, previous]);
     }
 
     function parseFieldName() {
@@ -585,22 +595,22 @@
     //   | NumberLiteral
     //   | ReservedIdentifier
     function parseFieldType() {
-        var key;
+        var key, rangeStart = previous;
 
         key = parseFieldName();
         if (token === Token.COLON) {
             consume(Token.COLON);
-            return {
+            return maybeAddRange({
                 type: Syntax.FieldType,
                 key: key,
                 value: parseTypeExpression()
-            };
+            }, [rangeStart, previous]);
         }
-        return {
+        return maybeAddRange({
             type: Syntax.FieldType,
             key: key,
             value: null
-        };
+        }, [rangeStart, previous]);
     }
 
     // RecordType := '{' FieldTypeList '}'
@@ -610,7 +620,7 @@
     //   | FieldType
     //   | FieldType ',' FieldTypeList
     function parseRecordType() {
-        var fields;
+        var fields, rangeStart = index - 1, rangeEnd;
 
         consume(Token.LBRACE, 'RecordType should start with {');
         fields = [];
@@ -624,11 +634,12 @@
                 }
             }
         }
+        rangeEnd = index;
         expect(Token.RBRACE);
-        return {
+        return maybeAddRange({
             type: Syntax.RecordType,
             fields: fields
-        };
+        }, [rangeStart, rangeEnd]);
     }
 
     // NameExpression :=
@@ -639,7 +650,7 @@
     // Identifier is the same as Token.NAME, including any dots, something like
     // namespace.module.MyClass
     function parseNameExpression() {
-        var name = value;
+        var name = value, rangeStart = index - name.length;
         expect(Token.NAME);
 
         if (token === Token.COLON && (
@@ -651,10 +662,10 @@
             expect(Token.NAME);
         }
 
-        return {
+        return maybeAddRange({
             type: Syntax.NameExpression,
             name: name
-        };
+        }, [rangeStart, previous]);
     }
 
     // TypeExpressionList :=
@@ -679,18 +690,18 @@
     //     '.<' TypeExpressionList '>'
     //   | '<' TypeExpressionList '>'   // this is extension of doctrine
     function parseTypeName() {
-        var expr, applications;
+        var expr, applications, startIndex = index - value.length;
 
         expr = parseNameExpression();
         if (token === Token.DOT_LT || token === Token.LT) {
             next();
             applications = parseTypeExpressionList();
             expect(Token.GT);
-            return {
+            return maybeAddRange({
                 type: Syntax.TypeApplication,
                 expression: expr,
                 applications: applications
-            };
+            }, [startIndex, previous]);
         }
         return expr;
     }
@@ -737,7 +748,7 @@
     //
     // Identifier is "new" or "this"
     function parseParametersType() {
-        var params = [], optionalSequence = false, expr, rest = false;
+        var params = [], optionalSequence = false, expr, rest = false, startIndex, restStartIndex = index - 3, nameStartIndex;
 
         while (token !== Token.RPAREN) {
             if (token === Token.REST) {
@@ -746,22 +757,25 @@
                 rest = true;
             }
 
+            startIndex = previous;
+
             expr = parseTypeExpression();
             if (expr.type === Syntax.NameExpression && token === Token.COLON) {
+                nameStartIndex = previous - expr.name.length;
                 // Identifier ':' TypeExpression
                 consume(Token.COLON);
-                expr = {
+                expr = maybeAddRange({
                     type: Syntax.ParameterType,
                     name: expr.name,
                     expression: parseTypeExpression()
-                };
+                }, [nameStartIndex, previous]);
             }
             if (token === Token.EQUAL) {
                 consume(Token.EQUAL);
-                expr = {
+                expr = maybeAddRange({
                     type: Syntax.OptionalType,
                     expression: expr
-                };
+                }, [startIndex, previous]);
                 optionalSequence = true;
             } else {
                 if (optionalSequence) {
@@ -769,10 +783,10 @@
                 }
             }
             if (rest) {
-                expr = {
+                expr = maybeAddRange({
                     type: Syntax.RestType,
                     expression: expr
-                };
+                }, [restStartIndex, previous]);
             }
             params.push(expr);
             if (token !== Token.RPAREN) {
@@ -790,7 +804,7 @@
     //   | TypeParameters '(' 'this' ':' TypeName ')' ResultType
     //   | TypeParameters '(' 'this' ':' TypeName ',' ParametersType ')' ResultType
     function parseFunctionType() {
-        var isNew, thisBinding, params, result, fnType;
+        var isNew, thisBinding, params, result, fnType, startIndex = index - value.length;
         utility.assert(token === Token.NAME && value === 'function', 'FunctionType should start with \'function\'');
         consume(Token.NAME);
 
@@ -827,11 +841,11 @@
             result = parseResultType();
         }
 
-        fnType = {
+        fnType = maybeAddRange({
             type: Syntax.FunctionType,
             params: params,
             result: result
-        };
+        }, [startIndex, previous]);
         if (thisBinding) {
             // avoid adding null 'new' and 'this' properties
             fnType['this'] = thisBinding;
@@ -852,13 +866,13 @@
     //   | RecordType
     //   | ArrayType
     function parseBasicTypeExpression() {
-        var context;
+        var context, startIndex;
         switch (token) {
         case Token.STAR:
             consume(Token.STAR);
-            return {
+            return maybeAddRange({
                 type: Syntax.AllLiteral
-            };
+            }, [previous - 1, previous]);
 
         case Token.LPAREN:
             return parseUnionType();
@@ -870,26 +884,28 @@
             return parseRecordType();
 
         case Token.NAME:
+            startIndex = index - value.length;
+
             if (value === 'null') {
                 consume(Token.NAME);
-                return {
+                return maybeAddRange({
                     type: Syntax.NullLiteral
-                };
+                }, [startIndex, previous]);
             }
 
             if (value === 'undefined') {
                 consume(Token.NAME);
-                return {
+                return maybeAddRange({
                     type: Syntax.UndefinedLiteral
-                };
+                }, [startIndex, previous]);
             }
 
             if (value === 'true' || value === 'false') {
                 consume(Token.NAME);
-                return {
+                return maybeAddRange({
                     type: Syntax.BooleanLiteralType,
                     value: value === 'true'
-                };
+                }, [startIndex, previous]);
             }
 
             context = Context.save();
@@ -905,17 +921,17 @@
 
         case Token.STRING:
             next();
-            return {
+            return maybeAddRange({
                 type: Syntax.StringLiteralType,
                 value: value
-            };
+            }, [previous - value.length - 2, previous]);
 
         case Token.NUMBER:
             next();
-            return {
+            return maybeAddRange({
                 type: Syntax.NumericLiteralType,
                 value: value
-            };
+            }, [previous - String(value).length, previous]);
 
         default:
             utility.throwError('unexpected token');
@@ -931,63 +947,65 @@
     //   | '?'
     //   | BasicTypeExpression '[]'
     function parseTypeExpression() {
-        var expr;
+        var expr, rangeStart;
 
         if (token === Token.QUESTION) {
+            rangeStart = index - 1;
             consume(Token.QUESTION);
             if (token === Token.COMMA || token === Token.EQUAL || token === Token.RBRACE ||
                     token === Token.RPAREN || token === Token.PIPE || token === Token.EOF ||
                     token === Token.RBRACK || token === Token.GT) {
-                return {
+                return maybeAddRange({
                     type: Syntax.NullableLiteral
-                };
+                }, [rangeStart, previous]);
             }
-            return {
+            return maybeAddRange({
                 type: Syntax.NullableType,
                 expression: parseBasicTypeExpression(),
                 prefix: true
-            };
-        }
-
-        if (token === Token.BANG) {
+            }, [rangeStart, previous]);
+        } else if (token === Token.BANG) {
+            rangeStart = index - 1;
             consume(Token.BANG);
-            return {
+            return maybeAddRange({
                 type: Syntax.NonNullableType,
                 expression: parseBasicTypeExpression(),
                 prefix: true
-            };
+            }, [rangeStart, previous]);
+        } else {
+            rangeStart = previous;
         }
 
         expr = parseBasicTypeExpression();
         if (token === Token.BANG) {
             consume(Token.BANG);
-            return {
+            return maybeAddRange({
                 type: Syntax.NonNullableType,
                 expression: expr,
                 prefix: false
-            };
+            }, [rangeStart, previous]);
         }
 
         if (token === Token.QUESTION) {
             consume(Token.QUESTION);
-            return {
+            return maybeAddRange({
                 type: Syntax.NullableType,
                 expression: expr,
                 prefix: false
-            };
+            }, [rangeStart, previous]);
         }
 
         if (token === Token.LBRACK) {
             consume(Token.LBRACK);
             expect(Token.RBRACK, 'expected an array-style type declaration (' + value + '[])');
-            return {
+            return maybeAddRange({
                 type: Syntax.TypeApplication,
-                expression: {
+                expression: maybeAddRange({
                     type: Syntax.NameExpression,
                     name: 'Array'
-                },
+                }, [rangeStart, previous]),
                 applications: [expr]
-            };
+            }, [rangeStart, previous]);
         }
 
         return expr;
@@ -1020,10 +1038,10 @@
             consume(Token.PIPE);
         }
 
-        return {
+        return maybeAddRange({
             type: Syntax.UnionType,
             elements: elements
-        };
+        }, [0, index]);
     }
 
     function parseTopParamType() {
@@ -1031,19 +1049,19 @@
 
         if (token === Token.REST) {
             consume(Token.REST);
-            return {
+            return maybeAddRange({
                 type: Syntax.RestType,
                 expression: parseTop()
-            };
+            }, [0, index]);
         }
 
         expr = parseTop();
         if (token === Token.EQUAL) {
             consume(Token.EQUAL);
-            return {
+            return maybeAddRange({
                 type: Syntax.OptionalType,
                 expression: expr
-            };
+            }, [0, index]);
         }
 
         return expr;
@@ -1056,6 +1074,8 @@
         length = source.length;
         index = 0;
         previous = 0;
+        addRange = opt && opt.range;
+        rangeOffset = opt && opt.startIndex || 0;
 
         next();
         expr = parseTop();
@@ -1081,6 +1101,8 @@
         length = source.length;
         index = 0;
         previous = 0;
+        addRange = opt && opt.range;
+        rangeOffset = opt && opt.startIndex || 0;
 
         next();
         expr = parseTopParamType();

--- a/test/parse.js
+++ b/test/parse.js
@@ -1387,125 +1387,149 @@ describe('parse', function () {
 
 describe('parseType', function () {
     it('union type closure-compiler extended', function () {
-        var type = doctrine.parseType("string|number");
+        var type = doctrine.parseType("string|number", {range: true});
         type.should.eql({
             type: 'UnionType',
             elements: [{
                 type: 'NameExpression',
-                name: 'string'
+                name: 'string',
+                range: [0, 6]
             }, {
                 type: 'NameExpression',
-                name: 'number'
-            }]
+                name: 'number',
+                range: [7, 13]
+            }],
+            range: [0, 13]
         });
     });
 
     it('empty union type', function () {
-        var type = doctrine.parseType("()");
+        var type = doctrine.parseType("()", {range: true});
         type.should.eql({
             type: 'UnionType',
-            elements: []
+            elements: [],
+            range: [0, 2]
         });
     });
 
     it('comma last array type', function () {
-        var type = doctrine.parseType("[string,]");
+        var type = doctrine.parseType("[string,]", {range: true});
         type.should.eql({
             type: 'ArrayType',
             elements: [{
                 type: 'NameExpression',
-                name: 'string'
-            }]
+                name: 'string',
+                range: [1, 7]
+            }],
+            range: [0, 9]
         });
     });
 
     it('array type of all literal', function () {
-        var type = doctrine.parseType("[*]");
+        var type = doctrine.parseType("[*]", {range: true});
         type.should.eql({
             type: 'ArrayType',
             elements: [{
-                type: 'AllLiteral'
-            }]
+                type: 'AllLiteral',
+                range: [1, 2]
+            }],
+            range: [0, 3]
         });
     });
 
     it('array type of nullable literal', function () {
-        var type = doctrine.parseType("[?]");
+        var type = doctrine.parseType("[?]", {range: true});
         type.should.eql({
             type: 'ArrayType',
             elements: [{
-                type: 'NullableLiteral'
-            }]
+                type: 'NullableLiteral',
+                range: [1, 2]
+            }],
+            range: [0, 3]
         });
     });
 
     it('comma last record type', function () {
-        var type = doctrine.parseType("{,}");
+        var type = doctrine.parseType("{,}", {range: true});
         type.should.eql({
             type: 'RecordType',
-            fields: []
+            fields: [],
+            range: [0, 3]
         });
     });
 
     it('type application', function () {
-        var type = doctrine.parseType("Array.<String>");
+        var type = doctrine.parseType("Array.<String>", {range: true});
         type.should.eql({
             type: 'TypeApplication',
             expression: {
                 type: 'NameExpression',
-                name: 'Array'
+                name: 'Array',
+                range: [0, 5]
             },
             applications: [{
                 type: 'NameExpression',
-                name: 'String'
-            }]
+                name: 'String',
+                range: [7, 13]
+            }],
+            range: [0, 14]
         });
     });
 
     it('type application with NullableLiteral', function () {
-        var type = doctrine.parseType("Array<?>");
+        var type = doctrine.parseType("Array<?>", {range: true});
         type.should.eql({
             type: 'TypeApplication',
             expression: {
                 type: 'NameExpression',
-                name: 'Array'
+                name: 'Array',
+                range: [0, 5]
             },
             applications: [{
-                type: 'NullableLiteral'
-            }]
+                type: 'NullableLiteral',
+                range: [6, 7]
+            }],
+            range: [0, 8]
         });
     });
 
     it('type application with multiple patterns', function () {
-        var type = doctrine.parseType("Array.<String, Number>");
+        var type = doctrine.parseType("Array.<String, Number>", {range: true});
         type.should.eql({
             type: 'TypeApplication',
             expression: {
                 type: 'NameExpression',
-                name: 'Array'
+                name: 'Array',
+                range: [0, 5]
             },
             applications: [{
                 type: 'NameExpression',
-                name: 'String'
+                name: 'String',
+                range: [7, 13]
             }, {
                 type: 'NameExpression',
-                name: 'Number'
-            }]
+                name: 'Number',
+                range: [15, 21]
+            }],
+            range: [0, 22]
         });
     });
 
     it('type application without dot', function () {
-        var type = doctrine.parseType("Array<String>");
+        var type = doctrine.parseType("Array<String>", {range: true});
         type.should.eql({
             type: 'TypeApplication',
             expression: {
                 type: 'NameExpression',
-                name: 'Array'
+                name: 'Array',
+                range: [0, 5]
             },
             applications: [{
                 type: 'NameExpression',
-                name: 'String'
-            }]
+                name: 'String',
+                range: [6, 12]
+            }],
+            range: [0, 13]
         });
     });
 
@@ -1525,163 +1549,193 @@ describe('parseType', function () {
     });
 
     it('function type simple', function () {
-        var type = doctrine.parseType("function()");
+        var type = doctrine.parseType("function()", {range: true});
         type.should.eql({
-		 "type": "FunctionType",
-		 "params": [],
-		 "result": null
-		});
+            "type": "FunctionType",
+            "params": [],
+            "result": null,
+            range: [0, 10]
+        });
     });
 
     it('function type with name', function () {
-        var type = doctrine.parseType("function(a)");
+        var type = doctrine.parseType("function(a)", {range: true});
         type.should.eql({
-		 "type": "FunctionType",
-		 "params": [
-		{
-		   "type": "NameExpression",
-		   "name": "a"
-		  }
-			 ],
-		 "result": null
-		});
+            "type": "FunctionType",
+            "params": [
+                {
+                    "type": "NameExpression",
+                    "name": "a",
+                    range: [9, 10]
+                }
+            ],
+            "result": null,
+            range: [0, 11]
+        });
     });
     it('function type with name and type', function () {
-        var type = doctrine.parseType("function(a:b)");
+        var type = doctrine.parseType("function(a:b)", {range: true});
         type.should.eql({
-		 "type": "FunctionType",
-		 "params": [
-		  {
-		   "type": "ParameterType",
-		   "name": "a",
-		   "expression": {
-		    "type": "NameExpression",
-		    "name": "b"
-		   }
-		  }
-		 ],
-		 "result": null
-		});
+            "type": "FunctionType",
+            "params": [
+                {
+                    "type": "ParameterType",
+                    "name": "a",
+                    "expression": {
+                        "type": "NameExpression",
+                        "name": "b",
+                        range: [11, 12]
+                    },
+                    range: [9, 12]
+                }
+            ],
+            "result": null,
+            range: [0, 13]
+        });
     });
     it('function type with optional param', function () {
-        var type = doctrine.parseType("function(a=)");
+        var type = doctrine.parseType("function(a=)", {range: true});
         type.should.eql({
-		 "type": "FunctionType",
-		 "params": [
-		  {
-		   "type": "OptionalType",
-		   "expression": {
-		    "type": "NameExpression",
-		    "name": "a"
-		   }
-		  }
-		 ],
-		 "result": null
-		});
+            "type": "FunctionType",
+            "params": [
+                {
+                    "type": "OptionalType",
+                    "expression": {
+                        "type": "NameExpression",
+                        "name": "a",
+                        range: [9, 10]
+                    },
+                    range: [9, 11]
+                }
+            ],
+            "result": null,
+            range: [0, 12]
+        });
     });
     it('function type with optional param name and type', function () {
-        var type = doctrine.parseType("function(a:b=)");
+        var type = doctrine.parseType("function(a:b=)", {range: true});
         type.should.eql({
-		 "type": "FunctionType",
-		 "params": [
-		  {
-		   "type": "OptionalType",
-		   "expression": {
-		    "type": "ParameterType",
-		    "name": "a",
-		    "expression": {
-		     "type": "NameExpression",
-		     "name": "b"
-		    }
-		   }
-		  }
-		 ],
-		 "result": null
-		});
+            "type": "FunctionType",
+            "params": [
+                {
+                    "type": "OptionalType",
+                    "expression": {
+                        "type": "ParameterType",
+                        "name": "a",
+                        "expression": {
+                            "type": "NameExpression",
+                            "name": "b",
+                            range: [11, 12]
+                        },
+                        range: [9, 12]
+                    },
+                    range: [9, 13]
+                }
+            ],
+            "result": null,
+            range: [0, 14]
+        });
     });
     it('function type with rest param', function () {
-        var type = doctrine.parseType("function(...a)");
+        var type = doctrine.parseType("function(...a)", {range: true});
         type.should.eql({
-		 "type": "FunctionType",
-		 "params": [
-		  {
-		   "type": "RestType",
-		   "expression": {
-		    "type": "NameExpression",
-		    "name": "a"
-		   }
-		  }
-		 ],
-		 "result": null
-		});
+            "type": "FunctionType",
+            "params": [
+                {
+                    "type": "RestType",
+                    "expression": {
+                        "type": "NameExpression",
+                        "name": "a",
+                        range: [12, 13]
+                    },
+                    range: [9, 13]
+                }
+            ],
+            "result": null,
+            range: [0, 14]
+        });
     });
     it('function type with rest param name and type', function () {
-        var type = doctrine.parseType("function(...a:b)");
+        var type = doctrine.parseType("function(...a:b)", {range: true});
         type.should.eql({
-		 "type": "FunctionType",
-		 "params": [
-		  {
-		   "type": "RestType",
-		   "expression": {
-		    "type": "ParameterType",
-		    "name": "a",
-		    "expression": {
-		     "type": "NameExpression",
-		     "name": "b"
-		    }
-		   }
-		  }
-		 ],
-		 "result": null
-		});
+            "type": "FunctionType",
+            "params": [
+                {
+                    "type": "RestType",
+                    "expression": {
+                        "type": "ParameterType",
+                        "name": "a",
+                        "expression": {
+                            "type": "NameExpression",
+                            "name": "b",
+                            range: [14, 15]
+                        },
+                        range: [12, 15]
+                    },
+                    range: [9, 15]
+                }
+            ],
+            "result": null,
+            range: [0, 16]
+        });
     });
 
     it('function type with optional rest param', function () {
-        var type = doctrine.parseType("function(...a=)");
+        var type = doctrine.parseType("function(...a=)", {range: true});
         type.should.eql({
-		 "type": "FunctionType",
-		 "params": [
-		  {
-			"type": "RestType",
-			"expression": {
-			   "type": "OptionalType",
-			   "expression": {
-			    "type": "NameExpression",
-			    "name": "a"
-			   }
-			  }
-			}
-		 ],
-		 "result": null
-		});
+            "type": "FunctionType",
+            "params": [
+                {
+                    "type": "RestType",
+                    "expression": {
+                        "type": "OptionalType",
+                        "expression": {
+                            "type": "NameExpression",
+                            "name": "a",
+                            range: [12, 13]
+                        },
+                        range: [12, 14]
+                    },
+                    range: [9, 14]
+                }
+            ],
+            "result": null,
+            range: [0, 15]
+        });
     });
     it('function type with optional rest param name and type', function () {
-        var type = doctrine.parseType("function(...a:b=)");
+        var type = doctrine.parseType("function(...a:b=)", {range: true});
         type.should.eql({
-		 "type": "FunctionType",
-		 "params": [
-		  {
-			"type": "RestType",
-			"expression": {
-			   "type": "OptionalType",
-			   "expression": {
-			    "type": "ParameterType",
-			    "name": "a",
-			    "expression": {
-			     "type": "NameExpression",
-			     "name": "b"
-			    }
-			  }
-			}
-		 }],
-		 "result": null
-		});
+            "type": "FunctionType",
+            "params": [
+                {
+                    "type": "RestType",
+                    "expression": {
+                        "type": "OptionalType",
+                        "expression": {
+                            "type": "ParameterType",
+                            "name": "a",
+                            "expression": {
+                                "type": "NameExpression",
+                                "name": "b",
+                                range: [14, 15]
+                            },
+                            range: [12, 15]
+                        },
+                        range: [12, 16]
+                    },
+                    range: [9, 16]
+                }
+            ],
+            "result": null,
+            range: [0, 17]
+        });
     });
 
     it('string value in type', function () {
         var type;
 
-        type = doctrine.parseType("{'ok':String}");
+        type = doctrine.parseType("{'ok':String}", {range: true});
         type.should.eql({
             "fields": [
                 {
@@ -1689,14 +1743,17 @@ describe('parseType', function () {
                     "type": "FieldType",
                     "value": {
                         "name": "String",
-                        "type": "NameExpression"
-                    }
+                        "type": "NameExpression",
+                        range: [6, 12]
+                    },
+                    range: [1, 12]
                 }
             ],
-            "type": "RecordType"
+            "type": "RecordType",
+            range: [0, 13]
         });
 
-        type = doctrine.parseType('{"\\r\\n\\t\\u2028\\x20\\u20\\b\\f\\v\\\r\n\\\n\\0\\07\\012\\o":String}');
+        type = doctrine.parseType('{"\\r\\n\\t\\u2028\\x20\\u20\\b\\f\\v\\\r\n\\\n\\0\\07\\012\\o":String}', {range: true});
         type.should.eql({
             "fields": [
                 {
@@ -1704,11 +1761,14 @@ describe('parseType', function () {
                     "type": "FieldType",
                     "value": {
                         "name": "String",
-                        "type": "NameExpression"
-                    }
+                        "type": "NameExpression",
+                        range: [46, 52]
+                    },
+                    range: [1, 52]
                 }
             ],
-            "type": "RecordType"
+            "type": "RecordType",
+            range: [0, 53]
         });
 
         doctrine.parseType.bind(doctrine, "{'ok\":String}").should.throw('unexpected quote');
@@ -1718,7 +1778,7 @@ describe('parseType', function () {
     it('number value in type', function () {
         var type;
 
-        type = doctrine.parseType("{20:String}");
+        type = doctrine.parseType("{20:String}", {range: true});
         type.should.eql({
             "fields": [
                 {
@@ -1726,11 +1786,14 @@ describe('parseType', function () {
                     "type": "FieldType",
                     "value": {
                         "name": "String",
-                        "type": "NameExpression"
-                    }
+                        "type": "NameExpression",
+                        range: [4, 10]
+                    },
+                    range: [1, 10]
                 }
             ],
-            "type": "RecordType"
+            "type": "RecordType",
+            range: [0, 11]
         });
 
         type = doctrine.parseType("{.2:String, 30:Number, 0x20:String}");
@@ -1824,116 +1887,134 @@ describe('parseType', function () {
 
     it('dotted type', function () {
         var type;
-        type = doctrine.parseType("Cocoa.Cappuccino");
+        type = doctrine.parseType("Cocoa.Cappuccino", {range: true});
         type.should.eql({
             "name": "Cocoa.Cappuccino",
-            "type": "NameExpression"
+            "type": "NameExpression",
+            range: [0, 16]
         });
     });
 
     it('rest array type', function () {
         var type;
-        type = doctrine.parseType("[string,...string]");
+        type = doctrine.parseType("[string,...string]", {range: true});
         type.should.eql({
             "elements": [
                 {
                     "name": "string",
-                    "type": "NameExpression"
+                    "type": "NameExpression",
+                    range: [1, 7]
                 },
                 {
                     "expression": {
                         "name": "string",
-                        "type": "NameExpression"
+                        "type": "NameExpression",
+                        range: [11, 17]
                     },
-                "type": "RestType"
+                    "type": "RestType",
+                    range: [8, 17]
                 }
             ],
-            "type": "ArrayType"
+            "type": "ArrayType",
+            range: [0, 18]
         });
     });
 
     it ('nullable type', function () {
         var type;
-        type = doctrine.parseType("string?");
+        type = doctrine.parseType("string?", {range: true});
         type.should.eql({
             "expression": {
                 "name": "string",
-                "type": "NameExpression"
+                "type": "NameExpression",
+                range: [0, 6]
             },
             "prefix": false,
-            "type": "NullableType"
+            "type": "NullableType",
+            range: [0, 7]
         });
     });
 
     it ('non-nullable type', function () {
         var type;
-        type = doctrine.parseType("string!");
+        type = doctrine.parseType("string!", {range: true});
         type.should.eql({
             "expression": {
                 "name": "string",
-                "type": "NameExpression"
+                "type": "NameExpression",
+                range: [0, 6]
             },
             "prefix": false,
-            "type": "NonNullableType"
+            "type": "NonNullableType",
+            range: [0, 7]
         });
     });
 
     it ('toplevel multiple pipe type', function () {
         var type;
-        type = doctrine.parseType("string|number|Test");
+        type = doctrine.parseType("string|number|Test", {range: true});
         type.should.eql({
             "elements": [
                 {
                     "name": "string",
-                    "type": "NameExpression"
+                    "type": "NameExpression",
+                    range: [0, 6]
                 },
                 {
                     "name": "number",
-                    "type": "NameExpression"
+                    "type": "NameExpression",
+                    range: [7, 13]
                 },
                 {
                     "name": "Test",
-                    "type": "NameExpression"
+                    "type": "NameExpression",
+                    range: [14, 18]
                 }
             ],
-            "type": "UnionType"
+            "type": "UnionType",
+            range: [0, 18]
         });
     });
 
     it('string literal type', function () {
         var type;
-        type = doctrine.parseType('"Hello, World"');
+        type = doctrine.parseType('"Hello, World"', {range: true});
         type.should.eql({
             type: 'StringLiteralType',
-            value: 'Hello, World'
+            value: 'Hello, World',
+            range: [0, 14]
         });
     });
 
     it('numeric literal type', function () {
         var type;
-        type = doctrine.parseType('32');
+        type = doctrine.parseType('32', {range: true});
         type.should.eql({
             type: 'NumericLiteralType',
-            value: 32
+            value: 32,
+            range: [0, 2]
         });
-        type = doctrine.parseType('-142.42');
+        type = doctrine.parseType('-142.42', {range: true});
         type.should.eql({
             type: 'NumericLiteralType',
-            value: -142.42
+            value: -142.42,
+            range: [0, 7]
         });
     });
 
     it('boolean literal type', function () {
         var type;
-        type = doctrine.parseType('true');
+        type = doctrine.parseType('true', {range: true});
         type.should.eql({
             type: 'BooleanLiteralType',
-            value: true
+            value: true,
+            range: [0, 4]
         });
-        type = doctrine.parseType('false');
+        type = doctrine.parseType('false', {range: true});
         type.should.eql({
             type: 'BooleanLiteralType',
-            value: false
+            value: false,
+            range: [0, 5]
         });
     });
 
@@ -1947,64 +2028,77 @@ describe('parseType', function () {
 
 describe('parseParamType', function () {
     it('question', function () {
-        var type = doctrine.parseParamType("?");
+        var type = doctrine.parseParamType("?", {range: true});
         type.should.eql({
-            type: 'NullableLiteral'
+            type: 'NullableLiteral',
+            range: [0, 1]
         });
     });
 
     it('question option', function () {
-        var type = doctrine.parseParamType("?=");
+        var type = doctrine.parseParamType("?=", {range: true});
         type.should.eql({
             type: 'OptionalType',
             expression: {
-                type: 'NullableLiteral'
-            }
+                type: 'NullableLiteral',
+                range: [0, 1]
+            },
+            range: [0, 2]
         });
     });
 
     it('function option parameters former', function () {
-        var type = doctrine.parseParamType("function(?, number)");
+        var type = doctrine.parseParamType("function(?, number)", {range: true});
         type.should.eql({
             type: 'FunctionType',
             params: [{
-                type: 'NullableLiteral'
+                type: 'NullableLiteral',
+                range: [9, 10]
             }, {
                 type: 'NameExpression',
-                name: 'number'
+                name: 'number',
+                range: [12, 18]
             }],
-            result: null
+            result: null,
+            range: [0, 19]
         });
     });
 
     it('function option parameters latter', function () {
-        var type = doctrine.parseParamType("function(number, ?)");
+        var type = doctrine.parseParamType("function(number, ?)", {range: true});
         type.should.eql({
             type: 'FunctionType',
             params: [{
                 type: 'NameExpression',
-                name: 'number'
+                name: 'number',
+                range: [9, 15]
             }, {
-                type: 'NullableLiteral'
+                type: 'NullableLiteral',
+                range: [17, 18]
             }],
-            result: null
+            result: null,
+            range: [0, 19]
         });
     });
 
     it('function type union', function () {
-        var type = doctrine.parseParamType("function(): ?|number");
+        var type = doctrine.parseParamType("function(): ?|number", {range: true});
         type.should.eql({
             type: 'UnionType',
             elements: [{
                 type: 'FunctionType',
                 params: [],
                 result: {
-                    type: 'NullableLiteral'
-                }
+                    type: 'NullableLiteral',
+                    range: [12, 13]
+                },
+                range: [0, 13]
             }, {
                 type: 'NameExpression',
-                name: 'number'
-            }]
+                name: 'number',
+                range: [14, 20]
+            }],
+            range: [0, 20]
         });
     });
 });
@@ -2363,6 +2457,87 @@ describe('optional params', function() {
         res.tags[1].should.have.property('lineNumber', 2);
         res.tags[2].should.have.property('lineNumber', 3);
         res.tags[3].should.have.property('lineNumber', 5);
+    });
+
+    it('range', function() {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * foo",
+                " * @constructor",
+                " * @param {string} foo",
+                " * @returns {string}",
+                " *",
+                " * @example",
+                " * f('blah'); // => undefined",
+                " */"
+            ].join('\n'),
+            { unwrap: true, range: true }
+        );
+
+
+        res.should.eql({
+          description: 'foo',
+          tags: [
+            { title: "constructor", description: null, range: [14, 26], type: null, name: null },
+            { title: "param", description: null, range: [30, 49], type: { type: "NameExpression", name: "string", range: [38, 44] }, name: "foo" },
+            { title: "returns", description: null, range: [53, 70], type: { type: "NameExpression", name: "string", range: [63, 69] } },
+            { title: "example", description: "f('blah'); // => undefined", range: [77, 115] }
+          ]
+        });
+    });
+
+    it('range with nested types', function() {
+        var res = doctrine.parse("@param {{foo: string,bar: {baz: number}}} beep boop", { range: true });
+
+        res.should.eql({
+          description: '',
+          tags: [
+              {
+                  title: "param",
+                  description: "boop",
+                  name: "beep",
+                  type: {
+                      type: "RecordType",
+                      fields: [
+                          {
+                              type: "FieldType",
+                              key: "foo",
+                              value: {
+                                  type: "NameExpression",
+                                  name: "string",
+                                  range: [14, 20]
+                              },
+                              range: [9, 20]
+                          },
+                          {
+                              type: "FieldType",
+                              key: "bar",
+                              value: {
+                                  type: "RecordType",
+                                  fields: [
+                                      {
+                                          type: "FieldType",
+                                          key: "baz",
+                                          value: {
+                                              type: "NameExpression",
+                                              name: "number",
+                                              range: [32, 38]
+                                          },
+                                          range: [27, 38]
+                                      }
+                                  ],
+                                  range: [26, 39]
+                              },
+                              range: [21, 39]
+                          }
+                      ],
+                      range: [8, 40]
+                  },
+                  range: [0, 51]
+              }
+          ]
+        });
     });
 
     it('example caption', function() {

--- a/test/parse.js
+++ b/test/parse.js
@@ -2540,6 +2540,21 @@ describe('optional params', function() {
         });
     });
 
+    it('range reaching end of tag', function() {
+        var res = doctrine.parse("/**@example", { range: true, unwrap: true });
+
+        res.should.eql({
+            description: '',
+            tags: [
+                {
+                    title: 'example',
+                    description: '',
+                    range: [3, 11]
+                }
+            ]
+        })
+    });
+
     it('example caption', function() {
         var res = doctrine.parse(
             [


### PR DESCRIPTION
This adds a `range` option to the `parse` API. When enabled, each node has a [start, end] range property indicating its location in the comment.

When computing the range with the `unwrap: true` option, the returned range needs to track indices in the original comment, not the unwrapped version. To implement that behavior, this commit updates the unwrapping logic to use a regular expression rather than a state machine. When converting an index, the parser and re-matches the original comment line-by-line, keeping track of the number of discarded "wrapping" characters.