### PR TITLE
fix: Allow array indexes in names

### DIFF
--- a/lib/doctrine.js
+++ b/lib/doctrine.js
@@ -268,7 +268,7 @@
 
         function scanIdentifier(last) {
             var identifier;
-            if (!esutils.code.isIdentifierStartES5(source.charCodeAt(index))) {
+            if (!esutils.code.isIdentifierStartES5(source.charCodeAt(index)) && !source[index].match(/[0-9]/)) {
                 return null;
             }
             identifier = advance();
@@ -296,13 +296,13 @@
                 return null;
             }
 
-            if (allowBrackets && source.charCodeAt(index) === 0x5B  /* '[' */) {
-                useBrackets = true;
-                name = advance();
-            }
-
-            if (!esutils.code.isIdentifierStartES5(source.charCodeAt(index))) {
-                return null;
+            if (source.charCodeAt(index) === 0x5B  /* '[' */) {
+                if (allowBrackets) {
+                    useBrackets = true;
+                    name = advance();
+                } else {
+                    return null;
+                }
             }
 
             name += scanIdentifier(last);

--- a/test/parse.js
+++ b/test/parse.js
@@ -498,6 +498,41 @@ describe('parse', function () {
         });
     });
 
+    it('param with array indexes', function () {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * @param {String} user.0",
+                "*/"
+            ].join('\n'), { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'param');
+        res.tags[0].should.have.property('name', 'user.0');
+        res.tags[0].should.have.property('type');
+        res.tags[0].type.should.eql({
+            type: 'NameExpression',
+            name: 'String'
+        });
+    });
+
+    it('param with array indexes and descriptions', function () {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * @param {String} user.0 The first element",
+                "*/"
+            ].join('\n'), { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'param');
+        res.tags[0].should.have.property('name', 'user.0');
+        res.tags[0].should.have.property('type');
+        res.tags[0].should.have.property('description', 'The first element');
+        res.tags[0].type.should.eql({
+            type: 'NameExpression',
+            name: 'String'
+        });
+    });
+
     it('arg with properties', function () {
         var res = doctrine.parse(
             [


### PR DESCRIPTION
Fixes #192 by allowing numeric identifiers in `scanIdentifier`