### PR TITLE
fix: Making sure union type stringification respects compact flag

### DIFF
--- a/lib/typed.js
+++ b/lib/typed.js
@@ -1133,7 +1133,7 @@
             for (i = 0, iz = node.elements.length; i < iz; ++i) {
                 result += stringifyImpl(node.elements[i], compact);
                 if ((i + 1) !== iz) {
-                    result += '|';
+                    result += compact ? '|' : ' | ';
                 }
             }
 

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -237,7 +237,7 @@ describe('Expression', function () {
                 type: doctrine.Syntax.NameExpression,
                 name: 'Number'
             }]
-        }).should.equal('(String|Number)');
+        }, {compact: false }).should.equal('(String | Number)');
 
         doctrine.type.stringify({
             type: doctrine.Syntax.UnionType,
@@ -248,7 +248,7 @@ describe('Expression', function () {
                 type: doctrine.Syntax.NameExpression,
                 name: 'Number'
             }]
-        }, { topLevel: true }).should.equal('String|Number');
+        }, { topLevel: true, compact: true }).should.equal('String|Number');
     });
 
     it('RestType', function () {
@@ -382,7 +382,7 @@ describe('Complex identity', function () {
             doctrine.type.parseType(data07)
         ).should.equal(data07);
 
-        var data08 = 'function (new: Date, a: Array.<String, Number>, b: (Number|String|Date)): HashMap.<String, Number>';
+        var data08 = 'function (new: Date, a: Array.<String, Number>, b: (Number | String | Date)): HashMap.<String, Number>';
         doctrine.type.stringify(
             doctrine.type.parseType(data08)
         ).should.equal(data08);


### PR DESCRIPTION
All other types on `stringifyImpl` currently supports the compact flag but `UnionType`. 

Currently regardless of the compact flag Uniontypes are printed as

```
A|B|C
```` 

This PR adds support for printing as:

```
A | B | C 
```

fixes: https://github.com/eslint/doctrine/issues/200