### PR TITLE
Use native String.prototype.trim instead of a custom implementation.

### DIFF
--- a/lib/doctrine.js
+++ b/lib/doctrine.js
@@ -90,10 +90,6 @@
             title === 'public' || title === 'private' || title === 'protected';
     }
 
-    function trim(str) {
-        return str.replace(/^\s+/, '').replace(/\s+$/, '');
-    }
-
     function unwrapComment(doc) {
         // JSDoc comment is following form
         //   /**
@@ -544,7 +540,7 @@
         };
 
         TagParser.prototype.parseDescription = function parseDescription() {
-            var description = trim(sliceSource(source, index, this._last));
+            var description = sliceSource(source, index, this._last).trim();
             if (description) {
                 if ((/^-\s+/).test(description)) {
                     description = description.substring(2);
@@ -555,15 +551,15 @@
         };
 
         TagParser.prototype.parseCaption = function parseDescription() {
-            var description = trim(sliceSource(source, index, this._last));
+            var description = sliceSource(source, index, this._last).trim();
             var captionStartTag = '<caption>';
             var captionEndTag = '</caption>';
             var captionStart = description.indexOf(captionStartTag);
             var captionEnd = description.indexOf(captionEndTag);
             if (captionStart >= 0 && captionEnd >= 0) {
-                this._tag.caption = trim(description.substring(
-                    captionStart + captionStartTag.length, captionEnd));
-                this._tag.description = trim(description.substring(captionEnd + captionEndTag.length));
+                this._tag.caption = description.substring(
+                    captionStart + captionStartTag.length, captionEnd).trim();
+                this._tag.description = description.substring(captionEnd + captionEndTag.length).trim();
             } else {
                 this._tag.description = description;
             }
@@ -585,7 +581,7 @@
                 'namespace': true,
                 'typedef': true
             };
-            kind = trim(sliceSource(source, index, this._last));
+            kind = sliceSource(source, index, this._last).trim();
             this._tag.kind = kind;
             if (!hasOwnProperty(kinds, kind)) {
                 if (!this.addError('Invalid kind name \'%0\'', kind)) {
@@ -597,7 +593,7 @@
 
         TagParser.prototype.parseAccess = function parseAccess() {
             var access;
-            access = trim(sliceSource(source, index, this._last));
+            access = sliceSource(source, index, this._last).trim();
             this._tag.access = access;
             if (access !== 'private' && access !== 'protected' && access !== 'public') {
                 if (!this.addError('Invalid access name \'%0\'', access)) {
@@ -610,7 +606,7 @@
         TagParser.prototype.parseThis = function parseThis() {
             // this name may be a name expression (e.g. {foo.bar}),
             // an union (e.g. {foo.bar|foo.baz}) or a name path (e.g. foo.bar)
-            var value = trim(sliceSource(source, index, this._last));
+            var value = sliceSource(source, index, this._last).trim();
             if (value && value.charAt(0) === '{') {
                 var gotType = this.parseType();
                 if (gotType && this._tag.type.type === 'NameExpression' || this._tag.type.type === 'UnionType') {
@@ -626,7 +622,7 @@
 
         TagParser.prototype.parseVariation = function parseVariation() {
             var variation, text;
-            text = trim(sliceSource(source, index, this._last));
+            text = sliceSource(source, index, this._last).trim();
             variation = parseFloat(text, 10);
             this._tag.variation = variation;
             if (isNaN(variation)) {
@@ -638,7 +634,7 @@
         };
 
         TagParser.prototype.ensureEnd = function () {
-            var shouldBeEmpty = trim(sliceSource(source, index, this._last));
+            var shouldBeEmpty = sliceSource(source, index, this._last).trim();
             if (shouldBeEmpty) {
                 if (!this.addError('Unknown content \'%0\'', shouldBeEmpty)) {
                     return false;
@@ -819,7 +815,7 @@
                 description += advance();
             }
 
-            return preserveWhitespace ? description : trim(description);
+            return preserveWhitespace ? description : description.trim();
         }
 
         function parse(comment, options) {


### PR DESCRIPTION
ES5 is required since #195 - let's remove some more code!