### PR TITLE
Add a fallback to the list of monospace fonts

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -80,7 +80,7 @@ blockquote {
 }
 
 code, pre {
-  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal;
+  font-family:Monaco, Bitstream Vera Sans Mono, Lucida Console, Terminal, monospace;
   color:#333;
   font-size:12px;
 }


### PR DESCRIPTION
Right now, I see this:

![variable-width serif code](https://user-images.githubusercontent.com/25517624/32146978-af5d1438-bcb5-11e7-9340-3a9817d0fa0c.png)
