### PR TITLE
Fix: Remove redundant LICENSE/README names from files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,7 @@
     "lib": "./lib"
   },
   "files": [
-    "lib",
-    "LICENSE.BSD",
-    "LICENSE.closure-compiler",
-    "LICENSE.esprima",
-    "README.md"
+    "lib"
   ],
   "maintainers": [
     {


### PR DESCRIPTION
npm already includes all of the files (even the ones for Closure Compiler and esprima). On the other hand, release-ops will no longer normalize line endings for the LICENSE files before publishing, but I assume those files' line endings are not as critical.

This should allow the project to be released, in theory.