### PR TITLE
New: support relative type references (fixes #205)

### DIFF
--- a/lib/typed.js
+++ b/lib/typed.js
@@ -335,6 +335,17 @@
 
     function scanTypeName() {
         var ch, ch2;
+        ch = source.charCodeAt(index);
+        if (ch === 0x2E  /* '.' */) {
+            // path must start with ./ or ../
+            if ((index + 1) >= length) {
+                return Token.ILLEGAL;
+            }
+            ch2 = source.charCodeAt(index + 1);
+            if (!(ch2 === 0x2E  /* '.' */ || ch2 === 0x2F /* '/' */)) {
+                return Token.ILLEGAL;
+            }
+        }
 
         value = advance();
         while (index < length && isTypeName(source.charCodeAt(index))) {
@@ -436,7 +447,7 @@
                     return token;
                 }
             }
-            token = Token.ILLEGAL;
+            token = scanTypeName();
             return token;
 
         case 0x3C:  /* '<' */
@@ -484,9 +495,10 @@
                 return token;
             }
 
-            // type string permits following case,
+            // type string permits following cases:
             //
             // namespace.module.MyClass
+            // ./path/to/module.MyClass
             //
             // this reduced 1 token TK_NAME
             utility.assert(isTypeName(ch));
@@ -648,7 +660,7 @@
     //
     // Tag identifier is one of "module", "external" or "event"
     // Identifier is the same as Token.NAME, including any dots, something like
-    // namespace.module.MyClass
+    // namespace.module.MyClass or ./path/to/module.MyClass
     function parseNameExpression() {
         var name = value, rangeStart = index - name.length;
         expect(Token.NAME);

--- a/test/parse.js
+++ b/test/parse.js
@@ -427,6 +427,42 @@ describe('parse', function () {
         });
     });
 
+    it('param with path', function () {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * @param {./path/to/module.MyClass} arg - The description.",
+                "*/"
+            ].join('\n'), { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'param');
+        res.tags[0].should.have.property('name', 'arg');
+        res.tags[0].should.have.property('description', 'The description.');
+        res.tags[0].should.have.property('type');
+        res.tags[0].type.should.eql({
+            type: 'NameExpression',
+            name: './path/to/module.MyClass'
+        });
+    });
+
+    it('param with .. path', function () {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * @param {../path/to/module.MyClass} arg - The description.",
+                "*/"
+            ].join('\n'), { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'param');
+        res.tags[0].should.have.property('name', 'arg');
+        res.tags[0].should.have.property('description', 'The description.');
+        res.tags[0].should.have.property('type');
+        res.tags[0].type.should.eql({
+            type: 'NameExpression',
+            name: '../path/to/module.MyClass'
+        });
+    });
+
     it('param with properties', function () {
         var res = doctrine.parse(
             [


### PR DESCRIPTION
Although #205 has not been marked as "accepted" yet, I wanted to see how involved the change would be.  It turns out to be straightforward to accept paths for type names, so I thought I would put up a pull request to demonstrate the scope of the change.

See https://github.com/google/closure-compiler/wiki/JS-Modules#type-references for background.  The change here makes it so this syntax is no longer considered illegal:
```js
/** @param {./foo.Foo} Foo */
function(Foo) {}
```

This allows types from other modules to be used without adding unused imports.
