### PR TITLE
New: support imported types (fixes #215)

### DIFF
--- a/lib/typed.js
+++ b/lib/typed.js
@@ -337,6 +337,26 @@
         var ch, ch2;
 
         value = advance();
+
+        // check for import("./path/to/module").Foo type
+        var importStart = 'import(';
+        if (source.slice(index - 1, index - 1 + importStart.length) === importStart) {
+            value = importStart;
+            index += importStart.length - 1;
+            // scan until closing )
+            while (index < length && source.charAt(index) !== ')') {
+                value += advance();
+            }
+            if (index >= length) {
+                return Token.ILLEGAL;
+            }
+            value += advance();
+
+            if (source.charCodeAt(index) !== 0x2E  /* '.' */) {
+                return Token.NAME;
+            }
+        }
+
         while (index < length && isTypeName(source.charCodeAt(index))) {
             ch = source.charCodeAt(index);
             if (ch === 0x2E  /* '.' */) {
@@ -484,9 +504,10 @@
                 return token;
             }
 
-            // type string permits following case,
+            // type string permits the following cases:
             //
             // namespace.module.MyClass
+            // import("./some/module").Type
             //
             // this reduced 1 token TK_NAME
             utility.assert(isTypeName(ch));

--- a/lib/typed.js
+++ b/lib/typed.js
@@ -338,10 +338,17 @@
 
         value = advance();
 
+        // check for typeof type
+        var typeofStart = 'typeof ';
+        if (source.slice(index - 1, index - 1 + typeofStart.length) === typeofStart) {
+            index += typeofStart.length - 1;
+            value += typeofStart.slice(1) + advance();
+        }
+
         // check for import("./path/to/module").Foo type
         var importStart = 'import(';
         if (source.slice(index - 1, index - 1 + importStart.length) === importStart) {
-            value = importStart;
+            value += importStart.slice(1);
             index += importStart.length - 1;
             // scan until closing )
             while (index < length && source.charAt(index) !== ')') {
@@ -508,6 +515,8 @@
             //
             // namespace.module.MyClass
             // import("./some/module").Type
+            // typeof namespace.module.MyClass
+            // typeof import("./some/module").Type
             //
             // this reduced 1 token TK_NAME
             utility.assert(isTypeName(ch));

--- a/test/parse.js
+++ b/test/parse.js
@@ -427,6 +427,23 @@ describe('parse', function () {
         });
     });
 
+    it('param with typeof', function() {
+        var res = doctrine.parse(
+            [
+                "/**",
+                " * @param {typeof String} userName",
+                "*/"
+            ].join('\n'), { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'param');
+        res.tags[0].should.have.property('name', 'userName');
+        res.tags[0].should.have.property('type');
+        res.tags[0].type.should.eql({
+            type: 'NameExpression',
+            name: 'typeof String'
+        });
+    });
+
     it('param with import', function () {
         var res = doctrine.parse(
             [
@@ -442,6 +459,24 @@ describe('parse', function () {
         res.tags[0].type.should.eql({
             type: 'NameExpression',
             name: 'import("path/to/module")'
+        });
+    });
+
+    it('param with typeof and import', function () {
+        var res = doctrine.parse(
+            [
+                '/**',
+                ' * @param {typeof import("path/to/module")} arg - The description.',
+                ' */'
+            ].join('\n'), { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'param');
+        res.tags[0].should.have.property('name', 'arg');
+        res.tags[0].should.have.property('description', 'The description.');
+        res.tags[0].should.have.property('type');
+        res.tags[0].type.should.eql({
+            type: 'NameExpression',
+            name: 'typeof import("path/to/module")'
         });
     });
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -427,6 +427,67 @@ describe('parse', function () {
         });
     });
 
+    it('param with import', function () {
+        var res = doctrine.parse(
+            [
+                '/**',
+                ' * @param {import("path/to/module")} arg - The description.',
+                ' */'
+            ].join('\n'), { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'param');
+        res.tags[0].should.have.property('name', 'arg');
+        res.tags[0].should.have.property('description', 'The description.');
+        res.tags[0].should.have.property('type');
+        res.tags[0].type.should.eql({
+            type: 'NameExpression',
+            name: 'import("path/to/module")'
+        });
+    });
+
+    it('param with import plus name', function () {
+        var res = doctrine.parse(
+            [
+                '/**',
+                ' * @param {import("path/to/module").SomeType} arg - The description.',
+                ' */'
+            ].join('\n'), { unwrap: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('title', 'param');
+        res.tags[0].should.have.property('name', 'arg');
+        res.tags[0].should.have.property('description', 'The description.');
+        res.tags[0].should.have.property('type');
+        res.tags[0].type.should.eql({
+            type: 'NameExpression',
+            name: 'import("path/to/module").SomeType'
+        });
+    });
+
+    it('param with bad import (missing closing paren)', function () {
+        var res = doctrine.parse(
+            [
+                '/**',
+                ' * @param {import("bad type} arg - The description.',
+                ' */'
+            ].join('\n'), { unwrap: true, recoverable: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('errors');
+        res.tags[0].errors.should.have.length(1);
+        res.tags[0].errors[0].should.equal('unexpected token');
+    });
+
+    it('param with bad import (misspelled import)', function () {
+        var res = doctrine.parse(
+            [
+                '/**',
+                ' * @param {impor("bad/spelling")} arg - The description.',
+                ' */'
+            ].join('\n'), { unwrap: true, recoverable: true });
+        res.tags.should.have.length(1);
+        res.tags[0].should.have.property('errors');
+        res.tags[0].errors.should.have.length(1);
+    });
+
     it('param with properties', function () {
         var res = doctrine.parse(
             [


### PR DESCRIPTION
I'm hoping to get documentation and type checking working together (see #205 for a previous effort with Closure Compiler and JSDoc).  TypeScript supports a very nice feature of allowing types from one module to be used in another.  For example (from the [TypeScript wiki](https://github.com/Microsoft/TypeScript/wiki/JSDoc-support-in-JavaScript)):
```js
// We can also import declarations from other files using 
// 'import' types:

/**
 * @param p { import("./a").Pet }
 */
function walk(p) {
    console.log(`Walking ${p.name}...`);
}
```

I'm proposing this change in hopes of using ESLint's `valid-jsdoc` rule together with TypeScript.  I'm happy to add additional tests or implement this in a different way if desired.

Fixes #215.
