### PR TITLE
Upgrade: eslint-release@1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 .nyc_output
 .cache
 npm-debug.log
+.eslint-release-info.json

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "coveralls": "^3.0.1",
     "dateformat": "^1.0.11",
     "eslint": "^1.10.3",
-    "eslint-release": "^0.11.1",
+    "eslint-release": "^1.0.0",
     "linefix": "^0.1.1",
     "mocha": "^3.4.2",
     "npm-license": "^0.3.1",
@@ -46,10 +46,11 @@
     "test": "nyc mocha",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint lib/",
-    "release": "eslint-release",
-    "ci-release": "eslint-ci-release",
-    "alpharelease": "eslint-prerelease alpha",
-    "betarelease": "eslint-prerelease beta"
+    "generate-release": "eslint-generate-release",
+    "generate-alpharelease": "eslint-generate-prerelease alpha",
+    "generate-betarelease": "eslint-generate-prerelease beta",
+    "generate-rcrelease": "eslint-generate-prerelease rc",
+    "publish-release": "eslint-publish-release"
   },
   "dependencies": {
     "esutils": "^2.0.2"


### PR DESCRIPTION
(refs https://github.com/eslint/eslint/issues/10631)

This updates `eslint-release` to allow the package to still be published now that we have 2FA enabled.