### PR TITLE
fix: support rest param that doesn't have a type expression

### DIFF
--- a/lib/typed.js
+++ b/lib/typed.js
@@ -731,7 +731,7 @@
     //
     // RestParameterType :=
     //     '...'
-    //     '...' Identifier
+    //   | '...' TypeExpression
     //
     // NonRestParametersType :=
     //     ParameterType ',' NonRestParametersType
@@ -759,8 +759,13 @@
 
             startIndex = previous;
 
-            expr = parseTypeExpression();
-            if (expr.type === Syntax.NameExpression && token === Token.COLON) {
+            if (token === Token.RPAREN) {
+                // function(...)
+                expr = null;
+            } else {
+                expr = parseTypeExpression();
+            }
+            if (expr && expr.type === Syntax.NameExpression && token === Token.COLON) {
                 nameStartIndex = previous - expr.name.length;
                 // Identifier ':' TypeExpression
                 consume(Token.COLON);

--- a/test/parse.js
+++ b/test/parse.js
@@ -1731,6 +1731,19 @@ describe('parseType', function () {
             range: [0, 17]
         });
     });
+    it('function type with rest param no type', function () {
+        var type = doctrine.parseType("function(...)", {range: true});
+        type.should.eql({
+            "type": "FunctionType",
+            "params": [{
+                "type": "RestType",
+                "expression": null,
+                range: [9, 12],
+            }],
+            "result": null,
+            range: [0, 13]
+        });
+    });
 
     it('string value in type', function () {
         var type;


### PR DESCRIPTION
Google Closure Compiler parses `function(...)` as `function(...?)`.
There are lots of such expressions in Closure Library (ex: [goog/base.js](https://github.com/google/closure-library/blob/bee9ced776b4700e8076a3466bd9d3f9ade2fb54/closure/goog/base.js#L1675))

doctrine should be able to parse it without errors expectedly, but actually throws `not reach to EOF` now.