### PR TITLE
Fix: allow `*` and `?` for function `this` type

### DIFF
--- a/lib/typed.js
+++ b/lib/typed.js
@@ -744,9 +744,7 @@
     //
     // OptionalParameterType := ParameterType=
     //
-    // ParameterType := TypeExpression | Identifier ':' TypeExpression
-    //
-    // Identifier is "new" or "this"
+    // ParameterType := TypeExpression
     function parseParametersType() {
         var params = [], optionalSequence = false, expr, rest = false, startIndex, restStartIndex = index - 3, nameStartIndex;
 
@@ -801,8 +799,8 @@
     // FunctionSignatureType :=
     //   | TypeParameters '(' ')' ResultType
     //   | TypeParameters '(' ParametersType ')' ResultType
-    //   | TypeParameters '(' 'this' ':' TypeName ')' ResultType
-    //   | TypeParameters '(' 'this' ':' TypeName ',' ParametersType ')' ResultType
+    //   | TypeParameters '(' 'this' ':' TypeExpression ')' ResultType
+    //   | TypeParameters '(' 'this' ':' TypeExpression ',' ParametersType ')' ResultType
     function parseFunctionType() {
         var isNew, thisBinding, params, result, fnType, startIndex = index - value.length;
         utility.assert(token === Token.NAME && value === 'function', 'FunctionType should start with \'function\'');
@@ -824,7 +822,7 @@
                 isNew = value === 'new';
                 consume(Token.NAME);
                 expect(Token.COLON);
-                thisBinding = parseTypeName();
+                thisBinding = parseTypeExpression();
                 if (token === Token.COMMA) {
                     consume(Token.COMMA);
                     params = parseParametersType();

--- a/test/parse.js
+++ b/test/parse.js
@@ -1636,6 +1636,64 @@ describe('parseType', function () {
             range: [0, 14]
         });
     });
+    it('function type with this', function () {
+        var type = doctrine.parseType("function(this:a, b)", {range: true});
+        type.should.eql({
+            "type": "FunctionType",
+            "params": [
+                {
+                    "type": "NameExpression",
+                    "name": "b",
+                    range: [17, 18]
+                }
+            ],
+            "result": null,
+            "this": {
+                "type": "NameExpression",
+                "name": "a",
+                range: [14, 15]
+            },
+            range: [0, 19]
+        });
+    });
+    it('function type with this all literal', function () {
+        var type = doctrine.parseType("function(this:*, b)", {range: true});
+        type.should.eql({
+            "type": "FunctionType",
+            "params": [
+                {
+                    "type": "NameExpression",
+                    "name": "b",
+                    range: [17, 18]
+                }
+            ],
+            "result": null,
+            "this": {
+                "type": "AllLiteral",
+                range: [14, 15]
+            },
+            range: [0, 19]
+        });
+    });
+    it('function type with this nullable literal', function () {
+        var type = doctrine.parseType("function(this:?, b)", {range: true});
+        type.should.eql({
+            "type": "FunctionType",
+            "params": [
+                {
+                    "type": "NameExpression",
+                    "name": "b",
+                    range: [17, 18]
+                }
+            ],
+            "result": null,
+            "this": {
+                "type": "NullableLiteral",
+                range: [14, 15]
+            },
+            range: [0, 19]
+        });
+    });
     it('function type with rest param', function () {
         var type = doctrine.parseType("function(...a)", {range: true});
         type.should.eql({


### PR DESCRIPTION
Google Closure Compiler parses `function(this:?)` and `function(this:*)` (ex: [goog/events/eventhandler.js](https://github.com/google/closure-library/blob/bee9ced776b4700e8076a3466bd9d3f9ade2fb54/closure/goog/events/eventhandler.js#L389))

doctrine should be able to parse it without errors expectedly, but actually throws not reach to EOF now.
